### PR TITLE
refactor: ErrorResponse.error() → from() 네이밍 변경

### DIFF
--- a/love/global-utils/src/main/kotlin/com/yapp/love/globalutils/exception/ErrorResponse.kt
+++ b/love/global-utils/src/main/kotlin/com/yapp/love/globalutils/exception/ErrorResponse.kt
@@ -10,7 +10,7 @@ data class ErrorResponse(
 ) {
     companion object {
         // [실패] ErrorCode 인터페이스를 사용하는 경우
-        fun error(errorCode: ErrorCode): ErrorResponse {
+        fun from(errorCode: ErrorCode): ErrorResponse {
             return ErrorResponse(
                 status = errorCode.getHttpStatus().value(),
                 code = errorCode.getCode(),
@@ -19,7 +19,7 @@ data class ErrorResponse(
         }
 
         // [실패] 메시지를 직접 덮어쓰는 경우
-        fun error(
+        fun from(
             errorCode: ErrorCode,
             message: String,
         ): ErrorResponse {

--- a/love/global-utils/src/main/kotlin/com/yapp/love/globalutils/exception/GlobalExceptionHandler.kt
+++ b/love/global-utils/src/main/kotlin/com/yapp/love/globalutils/exception/GlobalExceptionHandler.kt
@@ -26,7 +26,7 @@ class GlobalExceptionHandler {
 
         logger.warn(e) { "GlobalException: ${errorCode.getCode()}" }
 
-        val error = ErrorResponse.error(errorCode)
+        val error = ErrorResponse.from(errorCode)
 
         return ResponseEntity(error, errorCode.getHttpStatus())
     }
@@ -37,7 +37,7 @@ class GlobalExceptionHandler {
 
         logger.warn(e) { "Parameter binding failed" }
 
-        val error = ErrorResponse.error(globalErrorCode)
+        val error = ErrorResponse.from(globalErrorCode)
 
         return ResponseEntity(error, globalErrorCode.getHttpStatus())
     }
@@ -50,7 +50,7 @@ class GlobalExceptionHandler {
 
         logger.warn(e) { "HTTP method not supported" }
 
-        val error = ErrorResponse.error(globalErrorCode)
+        val error = ErrorResponse.from(globalErrorCode)
 
         return ResponseEntity(error, globalErrorCode.getHttpStatus())
     }
@@ -68,7 +68,7 @@ class GlobalExceptionHandler {
 
         logger.warn(e) { "Validation failed: $errorMsg" }
 
-        val error = ErrorResponse.error(globalErrorCode)
+        val error = ErrorResponse.from(globalErrorCode)
 
         return ResponseEntity(error, globalErrorCode.getHttpStatus())
     }
@@ -79,7 +79,7 @@ class GlobalExceptionHandler {
 
         logger.warn(ex) { "Malformed JSON request" }
 
-        val error = ErrorResponse.error(globalErrorCode)
+        val error = ErrorResponse.from(globalErrorCode)
 
         return ResponseEntity(error, globalErrorCode.getHttpStatus())
     }
@@ -90,7 +90,7 @@ class GlobalExceptionHandler {
 
         logger.warn(ex) { "Resource not found: ${ex.resourcePath}" }
 
-        val error = ErrorResponse.error(globalErrorCode)
+        val error = ErrorResponse.from(globalErrorCode)
 
         return ResponseEntity(error, globalErrorCode.getHttpStatus())
     }
@@ -102,7 +102,7 @@ class GlobalExceptionHandler {
         // Log4j2 Sentry Appender가 ERROR 로그를 자동으로 Sentry에 전송
         logger.error(ex) { "Unexpected error occurred" }
 
-        val error = ErrorResponse.error(globalErrorCode)
+        val error = ErrorResponse.from(globalErrorCode)
 
         return ResponseEntity(error, globalErrorCode.getHttpStatus())
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #9 
- [이전 PR](#11) 코멘트 반영(머지 전에 놓쳤던 부분 😅)
## 💻 작업 내용
- `ErrorResponse.error()` → `ErrorResponse.from()` 네이밍 변경

## 🧪 참고
- 기존 기능 동작은 동일하며 네이밍만 개선