### PR TITLE
feat: 유저 정보 조회 응답에 커플 연결 코드 추가

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/user/UserInfo.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/user/UserInfo.kt
@@ -3,17 +3,19 @@ package com.yapp.love.application.user
 import com.yapp.love.domain.user.model.User
 import com.yapp.love.domain.user.model.UserAdditionInfo
 
-data class UserInfo (
+data class UserInfo(
     val id: Long,
     val name: String,
     val email: String,
+    val inviteCode: String?,
 ) {
     companion object {
-        fun from(user: User, userAdditionInfo: UserAdditionInfo): UserInfo {
+        fun from(user: User, userAdditionInfo: UserAdditionInfo, inviteCode: String?): UserInfo {
             return UserInfo(
                 id = user.id!!,
                 name = userAdditionInfo.nickname,
                 email = user.email,
+                inviteCode = inviteCode,
             )
         }
     }

--- a/love/application/src/main/kotlin/com/yapp/love/application/user/UserService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/user/UserService.kt
@@ -1,7 +1,7 @@
 package com.yapp.love.application.user
 
+import com.yapp.love.domain.onboarding.InviteCodeRepository
 import com.yapp.love.domain.user.UserAdditionInfoRepository
-import com.yapp.love.domain.user.model.User
 import com.yapp.love.domain.user.repository.UserRepository
 import com.yapp.love.globalutils.exception.GlobalErrorCode
 import com.yapp.love.globalutils.exception.GlobalException
@@ -10,12 +10,14 @@ import org.springframework.stereotype.Service
 @Service
 class UserService(
     private val userRepository: UserRepository,
-    private val userAdditionInfoRepository: UserAdditionInfoRepository
+    private val userAdditionInfoRepository: UserAdditionInfoRepository,
+    private val inviteCodeRepository: InviteCodeRepository,
 ) {
     fun getUserById(id: Long): UserInfo {
         val user = userRepository.findById(id) ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "존재하지 않는 유저입니다.")
         val userAdditionInfo = userAdditionInfoRepository.findByUserId(id) ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "존재하지 않는 유저 정보입니다.")
+        val inviteCode = inviteCodeRepository.findByCreatorId(id)?.code
 
-        return UserInfo.from(user, userAdditionInfo)
+        return UserInfo.from(user, userAdditionInfo, inviteCode)
     }
 }

--- a/love/application/src/main/kotlin/com/yapp/love/application/user/UserService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/user/UserService.kt
@@ -16,7 +16,8 @@ class UserService(
     fun getUserById(id: Long): UserInfo {
         val user = userRepository.findById(id) ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "존재하지 않는 유저입니다.")
         val userAdditionInfo = userAdditionInfoRepository.findByUserId(id) ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "존재하지 않는 유저 정보입니다.")
-        val inviteCode = inviteCodeRepository.findByCreatorId(id)?.code
+        val inviteCode = (inviteCodeRepository.findByCreatorId(id)
+            ?: inviteCodeRepository.findUsedByUserId(id))?.code
 
         return UserInfo.from(user, userAdditionInfo, inviteCode)
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈

## 💻 작업 내용
- GET /api/v1/users/me 
  - 응답에 inviteCode 필드가 추가됩니다.                                                                                                                                                                                                                                                                                                                                                                                                 
  - 초대한 유저는 자신의 초대 코드(=커플코드) 반환
  - 초대된 유저는 상대방의 초대 코드(=커플코드) 반환                                                                                                                                                                                    


## 🧪 참고