### PR TITLE
[issue-58] fix: 날짜 관련 로직 수정 

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/goal/GoalService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/goal/GoalService.kt
@@ -119,6 +119,10 @@ class GoalService(
         val goal = getGoalEntityById(goalId)
         verifyUserOwnsGoal(userId, goal)
 
+        if (goal.goalStatus == GoalStatus.COMPLETED) {
+            throw GlobalException(GlobalErrorCode.INVALID_INPUT_VALUE, "종료된 목표는 수정할 수 없습니다.")
+        }
+
         // 종료일이 변경되고, 새 종료일이 오늘 이전으로 설정되면 인증 기록 삭제
         if (goal.endDate != command.endDate && command.endDate != null) {
             val today = LocalDate.now()
@@ -175,7 +179,10 @@ class GoalService(
             )
         }
 
+        val today = LocalDate.now()
         goal.goalStatus = GoalStatus.COMPLETED
+        goal.hasEndDate = true
+        goal.endDate = today
         goalRepository.save(goal)
 
         logger.info { "Goal $goalId completed by user $userId" }

--- a/love/application/src/test/kotlin/com/yapp/love/application/goal/GoalServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/goal/GoalServiceTest.kt
@@ -436,7 +436,48 @@ class GoalServiceTest : DescribeSpec({
             }
         }
 
-        context("권한 검증") {
+        context("종료된 목표 수정 방지") {
+
+            it("COMPLETED 목표를 수정하면 예외가 발생해야 함") {
+                // given
+                val goal =
+                    Goal(
+                        id = goalId,
+                        coupleId = coupleId,
+                        name = "운동하기",
+                        repeatCycle = RepeatCycle.DAILY,
+                        repeatCount = 1,
+                        startDate = LocalDate.of(2026, 1, 1),
+                        hasEndDate = true,
+                        endDate = LocalDate.now(),
+                        goalStatus = GoalStatus.COMPLETED,
+                        icon = GoalIcon.ICON_DEFAULT,
+                    )
+
+                val command =
+                    UpdateGoalCommand(
+                        name = "운동하기 수정",
+                        icon = GoalIcon.ICON_DEFAULT,
+                        repeatCycle = RepeatCycle.DAILY,
+                        repeatCount = 1,
+                        endDate = LocalDate.now().plusMonths(1),
+                    )
+
+                every { goalRepository.findActiveGoalById(goalId) } returns goal
+                every { coupleService.getCoupleInfoByUserId(userId) } returns coupleInfo
+
+                // when & then
+                val exception =
+                    shouldThrow<GlobalException> {
+                        goalService.updateGoal(userId, goalId, command)
+                    }
+
+                exception.getCustomMessage() shouldBe "종료된 목표는 수정할 수 없습니다."
+                verify(exactly = 0) { goalRepository.save(any()) }
+            }
+        }
+
+        context("권한 검증 - updateGoal") {
 
             it("다른 커플의 목표 수정 시 예외가 발생해야 함") {
                 // given
@@ -487,6 +528,132 @@ class GoalServiceTest : DescribeSpec({
                 // 권한 없으면 포토로그 삭제도 시도하지 않아야 함
                 verify(exactly = 0) {
                     photologService.deleteByGoalIdAfterEndDate(any(), any())
+                }
+            }
+        }
+    }
+
+    describe("completeGoal") {
+
+        val userId = 1L
+        val coupleId = 100L
+        val goalId = 200L
+        val partnerId = 2L
+
+        val coupleInfo =
+            CoupleInfo(
+                id = coupleId,
+                user1Id = userId,
+                user2Id = partnerId,
+                inviteCodeId = 1L,
+                anniversaryDate = LocalDate.of(2024, 1, 1),
+            )
+
+        context("진행 중인 목표를 종료하는 경우") {
+
+            it("goalStatus가 COMPLETED로 변경되고 endDate가 오늘로 설정되어야 함") {
+                // given
+                val today = LocalDate.now()
+                val goal =
+                    Goal(
+                        id = goalId,
+                        coupleId = coupleId,
+                        name = "운동하기",
+                        repeatCycle = RepeatCycle.DAILY,
+                        repeatCount = 1,
+                        startDate = today.minusMonths(1),
+                        hasEndDate = true,
+                        endDate = today.plusMonths(1),
+                        goalStatus = GoalStatus.IN_PROGRESS,
+                        icon = GoalIcon.ICON_EXERCISE,
+                    )
+
+                every { goalRepository.findActiveGoalById(goalId) } returns goal
+                every { coupleService.getCoupleInfoByUserId(userId) } returns coupleInfo
+                every { goalRepository.save(goal) } returns goal
+
+                // when
+                val result = goalService.completeGoal(userId, goalId)
+
+                // then
+                goal.goalStatus shouldBe GoalStatus.COMPLETED
+                goal.hasEndDate shouldBe true
+                goal.endDate shouldBe today
+                result.goalId shouldBe goalId
+            }
+
+            it("종료일이 없는 목표를 종료하면 hasEndDate가 true로 바뀌어야 함") {
+                // given
+                val today = LocalDate.now()
+                val goal =
+                    Goal(
+                        id = goalId,
+                        coupleId = coupleId,
+                        name = "독서",
+                        repeatCycle = RepeatCycle.WEEKLY,
+                        repeatCount = 3,
+                        startDate = today.minusMonths(1),
+                        hasEndDate = false,
+                        endDate = null,
+                        goalStatus = GoalStatus.IN_PROGRESS,
+                        icon = GoalIcon.ICON_BOOK,
+                    )
+
+                every { goalRepository.findActiveGoalById(goalId) } returns goal
+                every { coupleService.getCoupleInfoByUserId(userId) } returns coupleInfo
+                every { goalRepository.save(goal) } returns goal
+
+                // when
+                goalService.completeGoal(userId, goalId)
+
+                // then
+                goal.goalStatus shouldBe GoalStatus.COMPLETED
+                goal.hasEndDate shouldBe true
+                goal.endDate shouldBe today
+            }
+        }
+
+        context("진행 중이 아닌 목표를 종료하는 경우") {
+
+            it("이미 COMPLETED인 목표를 종료하면 예외가 발생해야 함") {
+                // given
+                val goal =
+                    Goal(
+                        id = goalId,
+                        coupleId = coupleId,
+                        name = "운동하기",
+                        repeatCycle = RepeatCycle.DAILY,
+                        repeatCount = 1,
+                        startDate = LocalDate.now().minusMonths(1),
+                        hasEndDate = true,
+                        endDate = LocalDate.now(),
+                        goalStatus = GoalStatus.COMPLETED,
+                        icon = GoalIcon.ICON_EXERCISE,
+                    )
+
+                every { goalRepository.findActiveGoalById(goalId) } returns goal
+                every { coupleService.getCoupleInfoByUserId(userId) } returns coupleInfo
+
+                // when & then
+                val exception =
+                    shouldThrow<GlobalException> {
+                        goalService.completeGoal(userId, goalId)
+                    }
+
+                exception.getCustomMessage() shouldBe "진행 중인 목표만 완료할 수 있습니다. (현재 상태: COMPLETED)"
+                verify(exactly = 0) { goalRepository.save(any()) }
+            }
+        }
+
+        context("존재하지 않는 목표를 종료하는 경우") {
+
+            it("NOT_FOUND 예외가 발생해야 함") {
+                // given
+                every { goalRepository.findActiveGoalById(goalId) } returns null
+
+                // when & then
+                shouldThrow<GlobalException> {
+                    goalService.completeGoal(userId, goalId)
                 }
             }
         }

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/goal/GoalJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/goal/GoalJpaRepository.kt
@@ -17,14 +17,16 @@ interface GoalJpaRepository : GoalRepository, JpaRepository<Goal, Long> {
         WHERE g.coupleId = :coupleId
         AND g.deletedAt IS NULL
         AND g.startDate <= :targetDate
-        AND (g.hasEndDate = false OR g.endDate >= :targetDate)
+        AND (g.hasEndDate = false OR g.endDate > :targetDate
+            OR (g.endDate = :targetDate AND g.goalStatus != com.yapp.love.domain.goal.model.GoalStatus.COMPLETED))
         ORDER BY
             CASE g.repeatCycle
                 WHEN 'DAILY' THEN 1
                 WHEN 'WEEKLY' THEN 2
                 WHEN 'MONTHLY' THEN 3
             END,
-            g.startDate ASC
+            g.startDate ASC,
+            g.id ASC
     """,
     )
     override fun findActiveGoalsByCoupleIdAndDate(

--- a/love/web/src/main/kotlin/com/yapp/love/web/goal/GoalApiSpec.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/goal/GoalApiSpec.kt
@@ -353,7 +353,11 @@ annotation class GetGoalApiSpec
                         ExampleObject(
                             name = "필수 값 누락 또는 조건에 맞지 않는 값",
                             value = """{"status": 400, "code": "G4000", "message": "입력값이 올바르지 않습니다."}""",
-                        )
+                        ),
+                        ExampleObject(
+                            name = "종료된 목표 수정 불가",
+                            value = """{"status": 400, "code": "G4000", "message": "종료된 목표는 수정할 수 없습니다."}""",
+                        ),
                     ],
                 ),
             ],


### PR DESCRIPTION

## #️⃣ 관련 이슈
- #58

## 💻 작업 내용
[조회 쿼리 개선]
- 오늘 끝내기한 목표가 오늘 목록에 계속 보이는 문제 → endDate = targetDate AND goalStatus != COMPLETED 조건 추가
- 삭제된 목표가 과거 조회에 나타나는 문제 → deletedAt IS NULL로 모든 날짜에서 완전 제외
- 동일 조건 목표 정렬 불안정 → g.id ASC tiebreaker 추가

[completeGoal 변경]
- goalStatus만 COMPLETED로 바꾸던 것 → endDate = 오늘, hasEndDate = true도 함께 세팅
- 과거 날짜 조회 시 종료 시점 기준으로 정확하게 필터링되도록

[updateGoal 보호]
- COMPLETED 목표의 endDate를 미래로 수정해서 목록에 다시 나타나는 문제 → goalStatus == COMPLETED이면 400


## 🧪 참고