### PR TITLE
fix: 목표 종료일이 시작일과 같아도 예외가 발생하지 않도록 수정

### DIFF
--- a/love/domain/src/main/kotlin/com/yapp/love/domain/goal/model/Goal.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/goal/model/Goal.kt
@@ -111,10 +111,7 @@ class Goal(
         val date = endDate
         if (date != null) {
             require(!date.isBefore(startDate)) {
-                "종료일은 시작일 이후여야 합니다."
-            }
-            require(!date.isEqual(startDate)) {
-                "종료일은 시작일과 달라야 합니다."
+                "종료일은 시작일과 같거나 시작일 이후여야 합니다."
             }
         }
     }

--- a/love/domain/src/test/kotlin/com/yapp/love/domain/goal/model/GoalTest.kt
+++ b/love/domain/src/test/kotlin/com/yapp/love/domain/goal/model/GoalTest.kt
@@ -143,12 +143,12 @@ class GoalTest {
                 assertThrows<IllegalArgumentException> {
                     goal.updateEndDate(true, LocalDate.now().minusDays(1))
                 }
-            assertTrue(exception.message!!.contains("종료일은 시작일 이후여야 합니다"))
+            assertTrue(exception.message!!.contains("종료일은 시작일과 같거나 시작일 이후여야 합니다"))
         }
 
         @Test
-        @DisplayName("updateEndDate로 시작일과 같은 종료일 설정 시 예외 발생")
-        fun updateEndDateWithDateEqualToStartDateFails() {
+        @DisplayName("updateEndDate로 시작일과 같은 종료일 설정 시 성공")
+        fun updateEndDateWithDateEqualToStartDateSucceeds() {
             val startDate = LocalDate.now()
             val goal =
                 Goal.of(
@@ -162,11 +162,10 @@ class GoalTest {
                     endDate = null,
                 )
 
-            val exception =
-                assertThrows<IllegalArgumentException> {
-                    goal.updateEndDate(true, startDate)
-                }
-            assertTrue(exception.message!!.contains("종료일은 시작일과 달라야 합니다"))
+            goal.updateEndDate(true, startDate)
+
+            assertTrue(goal.hasEndDate)
+            assertEquals(startDate, goal.endDate)
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #60 

## 💻 작업 내용
- 목표 종료일이 시작일과 같아도 예외가 발생하지 않도록 수정
- 
- 

## 🧪 참고