### PR TITLE
[issue-65] fix: 인증샷 목록 조회 기능 수정 및 변수명 통일

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/goal/GoalService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/goal/GoalService.kt
@@ -32,7 +32,7 @@ class GoalService(
             try {
                 Goal.of(
                     coupleId = command.coupleId,
-                    name = command.name,
+                    name = command.goalName,
                     icon = command.icon,
                     repeatCycle = command.repeatCycle,
                     repeatCount = command.repeatCount,
@@ -135,7 +135,7 @@ class GoalService(
         }
 
         try {
-            goal.name = command.name
+            goal.name = command.goalName
             goal.icon = command.icon
             goal.updateRepeatSettings(command.repeatCycle, command.repeatCount)
             goal.updateEndDate(command.endDate != null, command.endDate)

--- a/love/application/src/main/kotlin/com/yapp/love/application/goal/dto/GoalCommand.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/goal/dto/GoalCommand.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 data class CreateGoalCommand(
     val coupleId: Long,
-    val name: String,
+    val goalName: String,
     val icon: GoalIcon,
     val repeatCycle: RepeatCycle,
     val repeatCount: Int,
@@ -15,7 +15,7 @@ data class CreateGoalCommand(
 )
 
 data class UpdateGoalCommand(
-    val name: String,
+    val goalName: String,
     val icon: GoalIcon,
     val repeatCycle: RepeatCycle,
     val repeatCount: Int,

--- a/love/application/src/main/kotlin/com/yapp/love/application/goal/dto/GoalInfo.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/goal/dto/GoalInfo.kt
@@ -7,7 +7,7 @@ import com.yapp.love.domain.goal.model.RepeatCycle
 
 data class GoalInfo(
     val goalId: Long,
-    val name: String,
+    val goalName: String,
     val icon: GoalIcon,
     val goalStatus: GoalStatus,
     val repeatCycle: RepeatCycle,
@@ -21,7 +21,7 @@ data class GoalInfo(
         fun from(goal: Goal): GoalInfo {
             return GoalInfo(
                 goalId = goal.id!!,
-                name = goal.name,
+                goalName = goal.name,
                 icon = goal.icon,
                 repeatCycle = goal.repeatCycle,
                 repeatCount = goal.repeatCount,

--- a/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
@@ -33,10 +33,6 @@ class PhotologService(
         return photologRepository.findByGoalIdsAndVerificationDate(goalIds, verificationDate)
     }
 
-    fun getPhotologsByGoalId(goalId: Long): List<Photolog> {
-        return photologRepository.findByGoalIdOrderByVerificationDateDesc(goalId)
-    }
-
     /**
      * 특정 날짜 이후의 인증 기록 삭제
      *

--- a/love/application/src/test/kotlin/com/yapp/love/application/goal/GoalServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/goal/GoalServiceTest.kt
@@ -80,13 +80,13 @@ class GoalServiceTest : DescribeSpec({
                 // then
                 result.size shouldBe 2
                 result[0].goalId shouldBe 1L
-                result[0].name shouldBe "운동하기"
+                result[0].goalName shouldBe "운동하기"
                 result[0].repeatCycle shouldBe RepeatCycle.DAILY
                 result[0].icon shouldBe GoalIcon.ICON_EXERCISE
                 result[0].endDate shouldBe "2026-03-01"
 
                 result[1].goalId shouldBe 2L
-                result[1].name shouldBe "독서"
+                result[1].goalName shouldBe "독서"
                 result[1].repeatCycle shouldBe RepeatCycle.WEEKLY
                 result[1].icon shouldBe GoalIcon.ICON_BOOK
                 result[1].endDate shouldBe null
@@ -149,7 +149,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -191,7 +191,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -236,7 +236,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -277,7 +277,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -320,7 +320,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기 (수정)", // 이름만 변경
+                        goalName = "운동하기 (수정)", // 이름만 변경
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -363,7 +363,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -407,7 +407,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -456,7 +456,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기 수정",
+                        goalName = "운동하기 수정",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,
@@ -507,7 +507,7 @@ class GoalServiceTest : DescribeSpec({
 
                 val command =
                     UpdateGoalCommand(
-                        name = "운동하기",
+                        goalName = "운동하기",
                         icon = GoalIcon.ICON_DEFAULT,
                         repeatCycle = RepeatCycle.DAILY,
                         repeatCount = 1,

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/photolog/repository/PhotologRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/photolog/repository/PhotologRepository.kt
@@ -8,8 +8,6 @@ interface PhotologRepository {
 
     fun findById(id: Long): Photolog?
 
-    fun findByGoalIdOrderByVerificationDateDesc(goalId: Long): List<Photolog>
-
     fun findByGoalIdsAndVerificationDate(
         goalIds: List<Long>,
         verificationDate: LocalDate,

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/photolog/PhotologJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/photolog/PhotologJpaRepository.kt
@@ -11,8 +11,6 @@ import java.time.LocalDate
 
 @Repository
 interface PhotologJpaRepository : PhotologRepository, JpaRepository<Photolog, Long> {
-    override fun findByGoalIdOrderByVerificationDateDesc(goalId: Long): List<Photolog>
-
     @Query(
         """
         SELECT p FROM Photolog p

--- a/love/web/src/main/kotlin/com/yapp/love/web/goal/GoalController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/goal/GoalController.kt
@@ -30,7 +30,7 @@ class GoalController(
         val command =
             CreateGoalCommand(
                 coupleId = coupleId,
-                name = request.name,
+                goalName = request.goalName,
                 icon = request.icon,
                 repeatCycle = request.repeatCycle,
                 repeatCount = request.repeatCount,
@@ -76,7 +76,7 @@ class GoalController(
             goalsWithPhotologs.map { goalWithPhotologs ->
                 GoalItemResponse(
                     goalId = goalWithPhotologs.goal.id!!,
-                    name = goalWithPhotologs.goal.name,
+                    goalName = goalWithPhotologs.goal.name,
                     icon = goalWithPhotologs.goal.icon,
                     repeatCycle = goalWithPhotologs.goal.repeatCycle,
                     myCompleted = goalWithPhotologs.myPhotolog != null,
@@ -136,7 +136,7 @@ class GoalController(
     ): GoalResponse {
         val command =
             UpdateGoalCommand(
-                name = request.name,
+                goalName = request.goalName,
                 icon = request.icon,
                 repeatCycle = request.repeatCycle,
                 repeatCount = request.repeatCount,
@@ -168,7 +168,7 @@ class GoalController(
         val goalInfo = goalService.completeGoal(userId, goalId)
         return CompleteGoalResponse(
             goalId = goalInfo.goalId,
-            name = goalInfo.name,
+            goalName = goalInfo.goalName,
             goalStatus = goalInfo.goalStatus,
             completedAt = goalInfo.updatedAt,
         )

--- a/love/web/src/main/kotlin/com/yapp/love/web/goal/dto/GoalRequest.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/goal/dto/GoalRequest.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 
 data class CreateGoalRequest(
     @field:NotBlank(message = "목표 이름은 필수입니다")
-    val name: String,
+    val goalName: String,
     @field:NotNull(message = "아이콘은 필수입니다")
     val icon: GoalIcon,
     @field:NotNull(message = "반복 주기는 필수입니다")
@@ -24,7 +24,7 @@ data class CreateGoalRequest(
 
 data class UpdateGoalRequest(
     @field:NotBlank(message = "목표 이름은 필수입니다")
-    val name: String,
+    val goalName: String,
     @field:NotNull(message = "아이콘은 필수입니다")
     val icon: GoalIcon,
     @field:NotNull(message = "반복 주기는 필수입니다")

--- a/love/web/src/main/kotlin/com/yapp/love/web/goal/dto/GoalResponse.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/goal/dto/GoalResponse.kt
@@ -7,7 +7,7 @@ import com.yapp.love.domain.goal.model.RepeatCycle
 
 data class GoalResponse(
     val goalId: Long,
-    val name: String,
+    val goalName: String,
     val icon: GoalIcon,
     val repeatCycle: RepeatCycle,
     val repeatCount: Int,
@@ -20,7 +20,7 @@ data class GoalResponse(
         fun from(goalInfo: GoalInfo): GoalResponse {
             return GoalResponse(
                 goalId = goalInfo.goalId,
-                name = goalInfo.name,
+                goalName = goalInfo.goalName,
                 icon = goalInfo.icon,
                 repeatCycle = goalInfo.repeatCycle,
                 repeatCount = goalInfo.repeatCount,
@@ -41,7 +41,7 @@ data class GoalListResponse(
 
 data class GoalItemResponse(
     val goalId: Long,
-    val name: String,
+    val goalName: String,
     val icon: GoalIcon,
     val repeatCycle: RepeatCycle,
     val myCompleted: Boolean,
@@ -64,7 +64,7 @@ data class GoalDetailListResponse(
 
 data class GoalDetailItem(
     val goalId: Long,
-    val name: String,
+    val goalName: String,
     val icon: GoalIcon,
     val repeatCycle: RepeatCycle,
     val startDate: String,
@@ -74,7 +74,7 @@ data class GoalDetailItem(
         fun from(goalInfo: GoalInfo): GoalDetailItem {
             return GoalDetailItem(
                 goalId = goalInfo.goalId,
-                name = goalInfo.name,
+                goalName = goalInfo.goalName,
                 icon = goalInfo.icon,
                 repeatCycle = goalInfo.repeatCycle,
                 startDate = goalInfo.startDate,
@@ -91,7 +91,7 @@ data class DeleteGoalResponse(
 
 data class CompleteGoalResponse(
     val goalId: Long,
-    val name: String,
+    val goalName: String,
     val goalStatus: GoalStatus,
     val completedAt: String,
 )

--- a/love/web/src/main/kotlin/com/yapp/love/web/photolog/PhotologController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/photolog/PhotologController.kt
@@ -8,6 +8,7 @@ import com.yapp.love.domain.user.UserAdditionInfoRepository
 import com.yapp.love.web.auth.AuthUser
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import com.yapp.love.domain.goal.model.GoalIcon
 import com.yapp.love.domain.photolog.model.ReactionType
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
@@ -63,36 +64,59 @@ class PhotologController(
         )
     }
 
-    @Operation(summary = "목표별 인증샷 목록 조회")
-    @GetMapping("/goals/{goalId}")
-    fun getPhotologsByGoal(
+    @Operation(summary = "날짜별 인증샷 목록 조회")
+    @GetMapping("/goals/{targetDate}")
+    fun getPhotologsByDate(
         @AuthUser userId: Long,
-        @PathVariable goalId: Long,
+        @RequestParam targetDate: LocalDate,
     ): PhotologListResponse {
         val coupleInfo = coupleService.getCoupleInfoByUserId(userId)
+        val coupleId = coupleInfo.id!!
         val partnerId = coupleService.getPartnerUserIdByCoupleInfo(coupleInfo, userId)
-        val goal = goalService.getGoalById(userId, goalId)
 
         val myNickname = userAdditionInfoRepository.findByUserId(userId)?.nickname ?: "나"
         val partnerNickname = userAdditionInfoRepository.findByUserId(partnerId)?.nickname ?: "상대방"
 
-        val photologs = photologService.getPhotologsByGoalId(goalId)
+        val goalsWithPhotologs = goalService.getGoalsWithPhotologs(
+            coupleId = coupleId,
+            myUserId = userId,
+            partnerUserId = partnerId,
+            targetDate = targetDate,
+        )
 
         return PhotologListResponse(
-            goalId = goalId,
+            targetDate = targetDate,
             myNickname = myNickname,
             partnerNickname = partnerNickname,
-            goalTitle = goal.name,
-            photologs = photologs.map { photolog ->
-                PhotologDetailResponse(
-                    photologId = photolog.id!!,
-                    goalId = photolog.goalId,
-                    imageUrl = fileStoragePort.getPhotologUrl(photolog.goalId, photolog.fileName),
-                    comment = photolog.comment,
-                    verificationDate = photolog.verificationDate,
-                    isMine = photolog.userId == userId,
-                    uploaderName = if (photolog.userId == userId) myNickname else partnerNickname,
-                    uploadedAt = photolog.uploadedAt,
+            photologs = goalsWithPhotologs.map { goalWithPhotologs ->
+                GoalPhotologPair(
+                    goalId = goalWithPhotologs.goal.id!!,
+                    goalName = goalWithPhotologs.goal.name,
+                    goalIcon = goalWithPhotologs.goal.icon,
+                    myPhotolog = goalWithPhotologs.myPhotolog?.let {
+                        PhotologDetailResponse(
+                            photologId = it.id!!,
+                            goalId = it.goalId,
+                            imageUrl = fileStoragePort.getPhotologUrl(it.goalId, it.fileName),
+                            comment = it.comment,
+                            verificationDate = it.verificationDate,
+                            uploaderName = myNickname,
+                            uploadedAt = it.uploadedAt,
+                            reaction = it.reaction,
+                        )
+                    },
+                    partnerPhotolog = goalWithPhotologs.partnerPhotolog?.let {
+                        PhotologDetailResponse(
+                            photologId = it.id!!,
+                            goalId = it.goalId,
+                            imageUrl = fileStoragePort.getPhotologUrl(it.goalId, it.fileName),
+                            comment = it.comment,
+                            verificationDate = it.verificationDate,
+                            uploaderName = partnerNickname,
+                            uploadedAt = it.uploadedAt,
+                            reaction = it.reaction,
+                        )
+                    },
                 )
             },
         )
@@ -135,23 +159,31 @@ data class PhotologResponse(
     val verificationDate: LocalDate,
 )
 
+
 data class PhotologDetailResponse(
     val photologId: Long,
     val goalId: Long,
     val imageUrl: String,
     val comment: String?,
     val verificationDate: LocalDate,
-    val isMine: Boolean,
     val uploaderName: String,
     val uploadedAt: Instant,
+    val reaction: ReactionType?,
 )
 
 data class PhotologListResponse(
-    val goalId: Long,
+    val targetDate: LocalDate,
     val myNickname: String,
     val partnerNickname: String,
-    val goalTitle: String,
-    val photologs: List<PhotologDetailResponse>?,
+    val photologs: List<GoalPhotologPair>,
+)
+
+data class GoalPhotologPair(
+    val goalId: Long,
+    val goalName: String,
+    val goalIcon: GoalIcon,
+    val myPhotolog: PhotologDetailResponse?,
+    val partnerPhotolog: PhotologDetailResponse?,
 )
 
 data class ReactionRequest(


### PR DESCRIPTION

## #️⃣ 관련 이슈
- #65 

## 💻 작업 내용
- 목표별 -> 날짜별 조회로 변경
- 목표명 targetName을 통일(db 컬럼명 제외)
- 인증샷 조회시 reaction 조회 가능
- 응답 json 포맷 변경

## 🧪 참고
- 각 항목 구조: 목표 하나당 myPhotolog(내 인증샷) / partnerPhotolog(상대 인증샷) 쌍으로 구성되며, 해당 날짜에 인증하지 않았으면 null
- 정렬 기준: photologs 배열은 홈 화면 목표 순서와 동일
  1. 반복 주기: DAILY → WEEKLY → MONTHLY
  2. 같은 주기 내: 시작일 빠른 순
  3. 시작일도 같으면: 목표 ID 순