### PR TITLE
[issue-84] fix : 알림 및 찌르기 개선

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
@@ -18,7 +18,12 @@ class FcmTokenService(
 
     @Transactional
     fun registerToken(userId: Long, token: String, deviceId: String) {
-        // 같은 토큰을 가진 다른 유저 레코드 삭제 (기기 계정 전환 대응)
+        // 같은 기기의 다른 유저 레코드 unsubscribe 후 삭제 (기기 계정 전환 대응)
+        val oldTokens = fcmTokenRepository.findByDeviceIdAndUserIdNot(deviceId, userId)
+        oldTokens.forEach { fcmPushService.unsubscribeFromTopic(it.token, MARKETING_TOPIC) }
+        fcmTokenRepository.deleteAll(oldTokens)
+
+        // 같은 토큰을 가진 다른 유저 레코드 삭제 (토큰 미갱신 케이스 대응)
         fcmTokenRepository.deleteByTokenAndUserIdNot(token, userId)
 
         val existingToken = fcmTokenRepository.findByUserIdAndDeviceId(userId, deviceId)

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
@@ -30,16 +30,16 @@ class FcmTokenService(
             fcmTokenRepository.save(FcmToken.create(userId, token, deviceId))
         }
 
-        val isMarketingEnabled = runCatching { notificationSettingService.getSetting(userId).isMarketingPushEnabled }.getOrDefault(true)
+        val isMarketingEnabled = notificationSettingService.getSetting(userId).isMarketingPushEnabled
         if (isMarketingEnabled) {
             fcmPushService.subscribeToTopic(token, MARKETING_TOPIC)
         }
     }
 
     @Transactional
-    fun deleteToken(userId: Long, deviceId: String) {
-        val token = fcmTokenRepository.findByUserIdAndDeviceId(userId, deviceId) ?: return
-        fcmPushService.unsubscribeFromTopic(token.token, MARKETING_TOPIC)
-        fcmTokenRepository.delete(token)
+    fun deleteToken(userId: Long, token: String) {
+        val fcmToken = fcmTokenRepository.findByUserIdAndToken(userId, token) ?: return
+        fcmPushService.unsubscribeFromTopicOrThrow(token, MARKETING_TOPIC)
+        fcmTokenRepository.delete(fcmToken)
     }
 }

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
@@ -18,6 +18,9 @@ class FcmTokenService(
 
     @Transactional
     fun registerToken(userId: Long, token: String, deviceId: String) {
+        // 같은 토큰을 가진 다른 유저 레코드 삭제 (기기 계정 전환 대응)
+        fcmTokenRepository.deleteByTokenAndUserIdNot(token, userId)
+
         val existingToken = fcmTokenRepository.findByUserIdAndDeviceId(userId, deviceId)
 
         if (existingToken != null) {
@@ -31,5 +34,12 @@ class FcmTokenService(
         if (isMarketingEnabled) {
             fcmPushService.subscribeToTopic(token, MARKETING_TOPIC)
         }
+    }
+
+    @Transactional
+    fun deleteToken(userId: Long, deviceId: String) {
+        val token = fcmTokenRepository.findByUserIdAndDeviceId(userId, deviceId) ?: return
+        fcmPushService.unsubscribeFromTopic(token.token, MARKETING_TOPIC)
+        fcmTokenRepository.delete(token)
     }
 }

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationService.kt
@@ -20,6 +20,11 @@ class NotificationService(
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional(readOnly = true)
+    fun hasUnread(userId: Long): Boolean {
+        return notificationRepository.existsUnreadByUserId(userId)
+    }
+
+    @Transactional(readOnly = true)
     fun getNotifications(userId: Long, lastId: Long?, size: Int): NotificationPage {
         val results = notificationRepository.findByUserIdWithCursor(userId, lastId, size)
         val hasNext = results.size > size

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
@@ -39,7 +39,7 @@ class NotificationSettingService(
         return notificationSettingRepository.save(setting)
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     fun getSetting(userId: Long): NotificationSetting {
         return findByUserId(userId)
     }

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
@@ -92,7 +92,12 @@ class NotificationSettingService(
 
     private fun findByUserId(userId: Long): NotificationSetting {
         return notificationSettingRepository.findByUserId(userId)
-            ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "알림 설정을 찾을 수 없습니다.")
+            ?: notificationSettingRepository.save(NotificationSetting.create(
+                userId = userId,
+                isPokePushEnabled = false,
+                isMarketingPushEnabled = false,
+                isNightPushEnabled = false,
+            ))
     }
 
     private fun isNightTime(): Boolean {

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
@@ -31,12 +31,11 @@ class NotificationSettingService(
         isMarketingPushEnabled: Boolean,
         isNightPushEnabled: Boolean,
     ): NotificationSetting {
-        val setting = NotificationSetting.create(
-            userId = userId,
-            isPokePushEnabled = isPokePushEnabled,
-            isMarketingPushEnabled = isMarketingPushEnabled,
-            isNightPushEnabled = isNightPushEnabled,
-        )
+        val setting = notificationSettingRepository.findByUserId(userId)
+            ?: NotificationSetting.create(userId = userId)
+        setting.updatePokePush(isPokePushEnabled)
+        setting.updateMarketingPush(isMarketingPushEnabled)
+        setting.updateNightPush(isNightPushEnabled)
         return notificationSettingRepository.save(setting)
     }
 

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/port/FcmPushService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/port/FcmPushService.kt
@@ -12,6 +12,8 @@ interface FcmPushService {
 
     fun unsubscribeFromTopic(token: String, topic: String)
 
+    fun unsubscribeFromTopicOrThrow(token: String, topic: String)
+
     fun sendToTopic(
         topic: String,
         title: String,

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
@@ -28,6 +28,8 @@ class FcmTokenServiceTest : DescribeSpec({
 
     beforeEach {
         clearAllMocks()
+        every { fcmTokenRepository.findByDeviceIdAndUserIdNot(any(), any()) } returns emptyList()
+        every { fcmTokenRepository.deleteAll(any()) } just Runs
         every { fcmTokenRepository.deleteByTokenAndUserIdNot(any(), any()) } just Runs
         every { notificationSettingService.getSetting(any()) } returns NotificationSetting.create(userId = userId, isMarketingPushEnabled = true)
     }
@@ -61,6 +63,26 @@ class FcmTokenServiceTest : DescribeSpec({
                             it.token == token &&
                             it.deviceId == deviceId
                     })
+                }
+            }
+        }
+    }
+
+    describe("registerToken - 계정 전환") {
+
+        context("같은 기기에 다른 유저의 토큰이 존재하는 경우") {
+            it("이전 유저의 토큰을 unsubscribe 후 삭제한다") {
+                val otherUserId = 99L
+                val oldToken = FcmToken.create(userId = otherUserId, token = "old-token", deviceId = deviceId)
+                every { fcmTokenRepository.findByDeviceIdAndUserIdNot(deviceId, userId) } returns listOf(oldToken)
+                every { fcmTokenRepository.findByUserIdAndDeviceId(userId, deviceId) } returns null
+                every { fcmTokenRepository.save(any()) } answers { firstArg() }
+
+                fcmTokenService.registerToken(userId, token, deviceId)
+
+                verifyOrder {
+                    fcmPushService.unsubscribeFromTopic(oldToken.token, FcmTokenService.MARKETING_TOPIC)
+                    fcmTokenRepository.deleteAll(listOf(oldToken))
                 }
             }
         }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
@@ -4,6 +4,8 @@ import com.yapp.love.application.notification.port.FcmPushService
 import com.yapp.love.domain.notification.FcmTokenRepository
 import com.yapp.love.domain.notification.model.FcmToken
 import com.yapp.love.domain.notification.model.NotificationSetting
+import com.yapp.love.globalutils.exception.GlobalException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
@@ -93,13 +95,57 @@ class FcmTokenServiceTest : DescribeSpec({
             }
         }
 
-        context("알림 설정 조회가 실패하는 경우") {
-            it("기본값 true로 처리하여 마케팅 토픽을 구독한다") {
-                every { notificationSettingService.getSetting(userId) } throws RuntimeException("설정 조회 실패")
+        context("알림 설정이 존재하지 않는 경우") {
+            it("기본값 false로 처리하여 마케팅 토픽을 구독하지 않는다") {
+                every { notificationSettingService.getSetting(userId) } returns
+                    NotificationSetting.create(userId = userId, isMarketingPushEnabled = false)
 
                 fcmTokenService.registerToken(userId, token, deviceId)
 
-                verify(exactly = 1) { fcmPushService.subscribeToTopic(token, FcmTokenService.MARKETING_TOPIC) }
+                verify(exactly = 0) { fcmPushService.subscribeToTopic(any(), any()) }
+            }
+        }
+    }
+
+    describe("deleteToken") {
+
+        context("토큰이 존재하지 않는 경우") {
+            it("아무것도 하지 않는다") {
+                every { fcmTokenRepository.findByUserIdAndToken(userId, token) } returns null
+
+                fcmTokenService.deleteToken(userId, token)
+
+                verify(exactly = 0) { fcmPushService.unsubscribeFromTopicOrThrow(any(), any()) }
+                verify(exactly = 0) { fcmTokenRepository.delete(any()) }
+            }
+        }
+
+        context("토큰이 존재하는 경우") {
+            val fcmToken = FcmToken.create(userId = userId, token = token, deviceId = deviceId)
+
+            it("unsubscribe 후 토큰을 삭제한다") {
+                every { fcmTokenRepository.findByUserIdAndToken(userId, token) } returns fcmToken
+                every { fcmTokenRepository.delete(fcmToken) } just Runs
+
+                fcmTokenService.deleteToken(userId, token)
+
+                verifyOrder {
+                    fcmPushService.unsubscribeFromTopicOrThrow(token, FcmTokenService.MARKETING_TOPIC)
+                    fcmTokenRepository.delete(fcmToken)
+                }
+            }
+
+            it("unsubscribe 실패 시 예외를 던지고 토큰을 삭제하지 않는다") {
+                every { fcmTokenRepository.findByUserIdAndToken(userId, token) } returns fcmToken
+                every { fcmPushService.unsubscribeFromTopicOrThrow(any(), any()) } throws GlobalException(
+                    com.yapp.love.globalutils.exception.GlobalErrorCode.FCM_UNSUBSCRIBE_FAILED
+                )
+
+                shouldThrow<GlobalException> {
+                    fcmTokenService.deleteToken(userId, token)
+                }
+
+                verify(exactly = 0) { fcmTokenRepository.delete(any()) }
             }
         }
     }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
@@ -26,6 +26,7 @@ class FcmTokenServiceTest : DescribeSpec({
 
     beforeEach {
         clearAllMocks()
+        every { fcmTokenRepository.deleteByTokenAndUserIdNot(any(), any()) } just Runs
         every { notificationSettingService.getSetting(any()) } returns NotificationSetting.create(userId = userId, isMarketingPushEnabled = true)
     }
 

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationSettingServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationSettingServiceTest.kt
@@ -72,12 +72,16 @@ class NotificationSettingServiceTest : DescribeSpec({
         }
 
         context("설정이 존재하지 않는 경우") {
-            it("예외가 발생한다") {
+            it("기본값(전부 false)으로 설정을 생성하고 반환한다") {
                 every { notificationSettingRepository.findByUserId(userId) } returns null
+                every { notificationSettingRepository.save(any()) } answers { firstArg() }
 
-                shouldThrow<GlobalException> {
-                    service.getSetting(userId)
-                }
+                val result = service.getSetting(userId)
+
+                result.isPokePushEnabled shouldBe false
+                result.isMarketingPushEnabled shouldBe false
+                result.isNightPushEnabled shouldBe false
+                verify { notificationSettingRepository.save(any()) }
             }
         }
     }
@@ -94,12 +98,13 @@ class NotificationSettingServiceTest : DescribeSpec({
         }
 
         context("설정이 존재하지 않는 경우") {
-            it("예외가 발생한다") {
+            it("기본값으로 설정을 생성한 뒤 변경한다") {
                 every { notificationSettingRepository.findByUserId(userId) } returns null
+                every { notificationSettingRepository.save(any()) } answers { firstArg() }
 
-                shouldThrow<GlobalException> {
-                    service.updatePokePush(userId, true)
-                }
+                val result = service.updatePokePush(userId, true)
+
+                result.isPokePushEnabled shouldBe true
             }
         }
     }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationSettingServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationSettingServiceTest.kt
@@ -42,6 +42,7 @@ class NotificationSettingServiceTest : DescribeSpec({
 
     describe("initSetting") {
         it("알림 설정을 생성하고 저장한다") {
+            every { notificationSettingRepository.findByUserId(userId) } returns null
             every { notificationSettingRepository.save(any()) } answers { firstArg() }
 
             val result = service.initSetting(

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
@@ -14,5 +14,7 @@ interface FcmTokenRepository {
 
     fun delete(fcmToken: FcmToken)
 
+    fun deleteByTokenAndUserIdNot(token: String, userId: Long)
+
     fun deleteByUserId(userId: Long)
 }

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
@@ -14,7 +14,11 @@ interface FcmTokenRepository {
 
     fun findByUserIdAndToken(userId: Long, token: String): FcmToken?
 
+    fun findByDeviceIdAndUserIdNot(deviceId: String, userId: Long): List<FcmToken>
+
     fun delete(fcmToken: FcmToken)
+
+    fun deleteAll(fcmTokens: List<FcmToken>)
 
     fun deleteByTokenAndUserIdNot(token: String, userId: Long)
 

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
@@ -12,6 +12,8 @@ interface FcmTokenRepository {
         deviceId: String,
     ): FcmToken?
 
+    fun findByUserIdAndToken(userId: Long, token: String): FcmToken?
+
     fun delete(fcmToken: FcmToken)
 
     fun deleteByTokenAndUserIdNot(token: String, userId: Long)

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/notification/NotificationRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/notification/NotificationRepository.kt
@@ -10,6 +10,8 @@ interface NotificationRepository {
 
     fun findByUserIdWithCursor(userId: Long, lastId: Long?, size: Int): List<Notification>
 
+    fun existsUnreadByUserId(userId: Long): Boolean
+
     fun markAllAsReadByUserId(userId: Long)
 
     fun deleteCreatedBefore(threshold: LocalDateTime): Int

--- a/love/global-utils/src/main/kotlin/com/yapp/love/globalutils/exception/GlobalErrorCode.kt
+++ b/love/global-utils/src/main/kotlin/com/yapp/love/globalutils/exception/GlobalErrorCode.kt
@@ -40,6 +40,11 @@ enum class GlobalErrorCode(
     // ======================================================================
     NOT_FOUND(HttpStatus.NOT_FOUND, "G4040", "요청한 리소스를 찾을 수 없습니다."),
     COUPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "G4041", "커플을 찾을 수 없습니다."),
+
+    // ======================================================================
+    // 5. 외부 서비스
+    // ======================================================================
+    FCM_UNSUBSCRIBE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "G5001", "FCM 토픽 구독 해제에 실패했습니다. 잠시 후 다시 시도해주세요."),
     ;
 
     override fun getHttpStatus(): HttpStatus = httpStatus

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/fcm/FcmPushServiceImpl.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/fcm/FcmPushServiceImpl.kt
@@ -7,6 +7,8 @@ import com.google.firebase.messaging.MessagingErrorCode
 import com.google.firebase.messaging.Notification
 import com.yapp.love.application.notification.port.FcmPushService
 import com.yapp.love.domain.notification.FcmTokenRepository
+import com.yapp.love.globalutils.exception.GlobalErrorCode
+import com.yapp.love.globalutils.exception.GlobalException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
@@ -85,6 +87,16 @@ class FcmPushServiceImpl(
             logger.info { "토픽 구독 해제 완료: token=$token, topic=$topic" }
         } catch (e: FirebaseMessagingException) {
             logger.error(e) { "토픽 구독 해제 실패: token=$token, topic=$topic" }
+        }
+    }
+
+    override fun unsubscribeFromTopicOrThrow(token: String, topic: String) {
+        try {
+            firebaseMessaging.unsubscribeFromTopic(listOf(token), topic)
+            logger.info { "토픽 구독 해제 완료: token=$token, topic=$topic" }
+        } catch (e: FirebaseMessagingException) {
+            logger.error(e) { "토픽 구독 해제 실패: token=$token, topic=$topic" }
+            throw GlobalException(GlobalErrorCode.FCM_UNSUBSCRIBE_FAILED)
         }
     }
 

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
@@ -13,6 +13,8 @@ interface FcmTokenJpaRepositoryInterface : JpaRepository<FcmToken, Long> {
         deviceId: String,
     ): FcmToken?
 
+    fun findByUserIdAndToken(userId: Long, token: String): FcmToken?
+
     fun deleteByTokenAndUserIdNot(token: String, userId: Long)
 
     fun deleteByUserId(userId: Long)
@@ -39,6 +41,10 @@ class FcmTokenJpaRepository(
 
     override fun delete(fcmToken: FcmToken) {
         jpaRepository.delete(fcmToken)
+    }
+
+    override fun findByUserIdAndToken(userId: Long, token: String): FcmToken? {
+        return jpaRepository.findByUserIdAndToken(userId, token)
     }
 
     override fun deleteByTokenAndUserIdNot(token: String, userId: Long) {

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
@@ -14,6 +14,8 @@ interface FcmTokenJpaRepositoryInterface : JpaRepository<FcmToken, Long> {
     ): FcmToken?
 
     fun findByUserIdAndToken(userId: Long, token: String): FcmToken?
+    
+    fun findByDeviceIdAndUserIdNot(deviceId: String, userId: Long): List<FcmToken>
 
     fun deleteByTokenAndUserIdNot(token: String, userId: Long)
 
@@ -45,6 +47,14 @@ class FcmTokenJpaRepository(
 
     override fun findByUserIdAndToken(userId: Long, token: String): FcmToken? {
         return jpaRepository.findByUserIdAndToken(userId, token)
+    }
+
+    override fun findByDeviceIdAndUserIdNot(deviceId: String, userId: Long): List<FcmToken> {
+        return jpaRepository.findByDeviceIdAndUserIdNot(deviceId, userId)
+    }
+
+    override fun deleteAll(fcmTokens: List<FcmToken>) {
+        jpaRepository.deleteAll(fcmTokens)
     }
 
     override fun deleteByTokenAndUserIdNot(token: String, userId: Long) {

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
@@ -13,6 +13,8 @@ interface FcmTokenJpaRepositoryInterface : JpaRepository<FcmToken, Long> {
         deviceId: String,
     ): FcmToken?
 
+    fun deleteByTokenAndUserIdNot(token: String, userId: Long)
+
     fun deleteByUserId(userId: Long)
 }
 
@@ -37,6 +39,10 @@ class FcmTokenJpaRepository(
 
     override fun delete(fcmToken: FcmToken) {
         jpaRepository.delete(fcmToken)
+    }
+
+    override fun deleteByTokenAndUserIdNot(token: String, userId: Long) {
+        jpaRepository.deleteByTokenAndUserIdNot(token, userId)
     }
 
     override fun deleteByUserId(userId: Long) {

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/NotificationJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/NotificationJpaRepository.kt
@@ -15,6 +15,8 @@ interface NotificationJpaRepositoryInterface : JpaRepository<Notification, Long>
 
     fun findByUserIdAndIdLessThanOrderByIdDesc(userId: Long, id: Long, pageable: Pageable): List<Notification>
 
+    fun existsByUserIdAndIsReadFalse(userId: Long): Boolean
+
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true, n.readAt = CURRENT_TIMESTAMP WHERE n.userId = :userId AND n.isRead = false")
     fun markAllAsReadByUserId(userId: Long)
@@ -43,6 +45,10 @@ class NotificationJpaRepository(
         } else {
             jpaRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, pageable)
         }
+    }
+
+    override fun existsUnreadByUserId(userId: Long): Boolean {
+        return jpaRepository.existsByUserIdAndIsReadFalse(userId)
     }
 
     override fun markAllAsReadByUserId(userId: Long) {

--- a/love/web/src/main/kotlin/com/yapp/love/web/admin/AdminNotificationController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/admin/AdminNotificationController.kt
@@ -5,6 +5,7 @@ import com.yapp.love.application.notification.port.FcmPushService
 import com.yapp.love.globalutils.exception.GlobalErrorCode
 import com.yapp.love.globalutils.exception.GlobalException
 import com.yapp.love.web.admin.dto.MarketingPushRequest
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Hidden
 @Tag(name = "Admin Notification", description = "어드민 알림 API")
 @RestController
 @RequestMapping("/api/admin/notifications")

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationApiSpec.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationApiSpec.kt
@@ -71,6 +71,42 @@ annotation class RegisterFcmTokenApiSpec
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 @Operation(
+    summary = "읽지 않은 알림 존재 여부 조회",
+    description = "읽지 않은 알림이 있으면 true, 없으면 false를 반환합니다. 알림 탭 뱃지 표시 등에 활용합니다.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = [Content(schema = Schema(implementation = com.yapp.love.web.notification.dto.response.HasUnreadResponse::class))],
+        ),
+        ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "인증되지 않은 사용자",
+                            value = """{"status": 401, "code": "G4010", "message": "인증되지 않은 사용자입니다."}""",
+                        ),
+                        ExampleObject(
+                            name = "토큰 만료",
+                            value = """{"status": 401, "code": "G4011", "message": "토큰이 만료되었습니다."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+annotation class HasUnreadApiSpec
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(
     summary = "알림 목록 조회",
     description = "내 알림 목록을 최신순으로 조회합니다. (커서 기반 페이지네이션)\n\n" +
         "- 첫 요청: 파라미터 없이 호출\n" +

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationApiSpec.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationApiSpec.kt
@@ -71,6 +71,57 @@ annotation class RegisterFcmTokenApiSpec
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 @Operation(
+    summary = "FCM 토큰 삭제",
+    description = "로그아웃 시 디바이스 FCM 토큰을 삭제하고 마케팅 topic 구독을 해제합니다. 토큰이 존재하지 않으면 무시됩니다.\n\n" +
+        "FCM topic 구독 해제 실패 시 500이 반환되며, 이 경우 DB 삭제도 롤백됩니다. 재시도해주세요.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(
+            responseCode = "200",
+            description = "토큰 삭제 성공",
+        ),
+        ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "인증되지 않은 사용자",
+                            value = """{"status": 401, "code": "G4010", "message": "인증되지 않은 사용자입니다."}""",
+                        ),
+                        ExampleObject(
+                            name = "토큰 만료",
+                            value = """{"status": 401, "code": "G4011", "message": "토큰이 만료되었습니다."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "FCM 구독 해제 실패",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "FCM 구독 해제 실패",
+                            value = """{"status": 500, "code": "G5001", "message": "FCM 토픽 구독 해제에 실패했습니다. 잠시 후 다시 시도해주세요."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+annotation class DeleteFcmTokenApiSpec
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(
     summary = "읽지 않은 알림 존재 여부 조회",
     description = "읽지 않은 알림이 있으면 true, 없으면 false를 반환합니다. 알림 탭 뱃지 표시 등에 활용합니다.",
 )

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationController.kt
@@ -4,6 +4,7 @@ import com.yapp.love.application.notification.FcmTokenService
 import com.yapp.love.application.notification.NotificationService
 import com.yapp.love.application.notification.NotificationSettingService
 import com.yapp.love.web.auth.AuthUser
+import com.yapp.love.web.notification.dto.request.DeleteFcmTokenRequest
 import com.yapp.love.web.notification.dto.request.FcmTokenRequest
 import com.yapp.love.web.notification.dto.request.InitNotificationSettingRequest
 import com.yapp.love.web.notification.dto.request.PushSettingRequest
@@ -30,6 +31,15 @@ class NotificationController(
         @Valid @RequestBody request: FcmTokenRequest,
     ) {
         fcmTokenService.registerToken(userId, request.token, request.deviceId)
+    }
+
+    @DeleteFcmTokenApiSpec
+    @DeleteMapping("/fcm-token")
+    fun deleteFcmToken(
+        @AuthUser userId: Long,
+        @Valid @RequestBody request: DeleteFcmTokenRequest,
+    ) {
+        fcmTokenService.deleteToken(userId, request.token)
     }
 
     @HasUnreadApiSpec

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationController.kt
@@ -7,6 +7,7 @@ import com.yapp.love.web.auth.AuthUser
 import com.yapp.love.web.notification.dto.request.FcmTokenRequest
 import com.yapp.love.web.notification.dto.request.InitNotificationSettingRequest
 import com.yapp.love.web.notification.dto.request.PushSettingRequest
+import com.yapp.love.web.notification.dto.response.HasUnreadResponse
 import com.yapp.love.web.notification.dto.response.NotificationListResponse
 import com.yapp.love.web.notification.dto.response.NotificationResponse
 import com.yapp.love.web.notification.dto.response.NotificationSettingResponse
@@ -29,6 +30,14 @@ class NotificationController(
         @Valid @RequestBody request: FcmTokenRequest,
     ) {
         fcmTokenService.registerToken(userId, request.token, request.deviceId)
+    }
+
+    @HasUnreadApiSpec
+    @GetMapping("/unread")
+    fun hasUnread(
+        @AuthUser userId: Long,
+    ): HasUnreadResponse {
+        return HasUnreadResponse(hasUnread = notificationService.hasUnread(userId))
     }
 
     @GetNotificationsApiSpec

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/dto/request/DeleteFcmTokenRequest.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/dto/request/DeleteFcmTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.yapp.love.web.notification.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class DeleteFcmTokenRequest(
+    @field:NotBlank(message = "FCM 토큰은 필수입니다.")
+    val token: String,
+)

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/dto/response/HasUnreadResponse.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/dto/response/HasUnreadResponse.kt
@@ -1,0 +1,5 @@
+package com.yapp.love.web.notification.dto.response
+
+data class HasUnreadResponse(
+    val hasUnread: Boolean,
+)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #84 

## 💻 작업 내용 
- FCM 토큰 삭제 API 추가 (DELETE /api/v1/notifications/fcm-token)                                                                                                           
    - 로그아웃 시 topic unsubscribe 및 토큰 삭제                                                                                                                              
    - unsubscribe 실패 시 예외를 던지고 DB 삭제 롤백 (토큰 유실로 인한 영구 구독 방지)                                                                                        
- FCM 토큰 등록 시 동일 기기 계정 전환 대응                                                                                                                                 
  - 동일 기기에 등록된 다른 계정의 FCM 토큰 unsubscribe 후 삭제
  - 동일 토큰을 가진 다른 유저 레코드 삭제 (토큰 미갱신 케이스 대응)
- 알림 설정 미존재 시 기본값(전부 false)으로 자동 생성 (getOrCreate)
  - initSetting upsert 방식으로 변경 — FCM 토큰 등록 선행 시 unique constraint 위반 버그 수정
  - 설정 신규 생성 시 UnexpectedRollbackException 버그 수정

## 🧪 참고
  - 마케팅 푸시 기본값: 온보딩에서 명시적으로 설정하지 않으면 false (미구독 상태로 시작)
  - FCM 구독 해제 실패 시 토큰 삭제 불가 → 프론트에서 재시도 유도 필요 (G5001 에러 코드)