### PR TITLE
feat: 야간 마케팅 푸쉬 알림 설정 적용

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/FcmTokenService.kt
@@ -1,6 +1,5 @@
 package com.yapp.love.application.notification
 
-import com.yapp.love.application.notification.port.FcmPushService
 import com.yapp.love.domain.notification.FcmTokenRepository
 import com.yapp.love.domain.notification.model.FcmToken
 import org.springframework.stereotype.Service
@@ -9,18 +8,11 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class FcmTokenService(
     private val fcmTokenRepository: FcmTokenRepository,
-    private val fcmPushService: FcmPushService,
-    private val notificationSettingService: NotificationSettingService,
 ) {
-    companion object {
-        const val MARKETING_TOPIC = "all-users"
-    }
-
     @Transactional
     fun registerToken(userId: Long, token: String, deviceId: String) {
-        // 같은 기기의 다른 유저 레코드 unsubscribe 후 삭제 (기기 계정 전환 대응)
+        // 같은 기기의 다른 유저 레코드 삭제 (기기 계정 전환 대응)
         val oldTokens = fcmTokenRepository.findByDeviceIdAndUserIdNot(deviceId, userId)
-        oldTokens.forEach { fcmPushService.unsubscribeFromTopic(it.token, MARKETING_TOPIC) }
         fcmTokenRepository.deleteAll(oldTokens)
 
         // 같은 토큰을 가진 다른 유저 레코드 삭제 (토큰 미갱신 케이스 대응)
@@ -34,17 +26,11 @@ class FcmTokenService(
         } else {
             fcmTokenRepository.save(FcmToken.create(userId, token, deviceId))
         }
-
-        val isMarketingEnabled = notificationSettingService.getSetting(userId).isMarketingPushEnabled
-        if (isMarketingEnabled) {
-            fcmPushService.subscribeToTopic(token, MARKETING_TOPIC)
-        }
     }
 
     @Transactional
     fun deleteToken(userId: Long, token: String) {
         val fcmToken = fcmTokenRepository.findByUserIdAndToken(userId, token) ?: return
-        fcmPushService.unsubscribeFromTopicOrThrow(token, MARKETING_TOPIC)
         fcmTokenRepository.delete(fcmToken)
     }
 }

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/MarketingPushService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/MarketingPushService.kt
@@ -1,0 +1,43 @@
+package com.yapp.love.application.notification
+
+import com.yapp.love.application.notification.port.FcmPushService
+import com.yapp.love.domain.notification.FcmTokenRepository
+import com.yapp.love.domain.notification.NotificationSettingRepository
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.LocalTime
+import java.time.ZoneId
+
+@Service
+class MarketingPushService(
+    private val notificationSettingRepository: NotificationSettingRepository,
+    private val fcmTokenRepository: FcmTokenRepository,
+    private val fcmPushService: FcmPushService,
+    private val clock: Clock = Clock.system(ZoneId.of("Asia/Seoul"))
+) {
+    companion object {
+        private const val NIGHT_START_HOUR = 21
+        private const val NIGHT_END_HOUR = 8
+    }
+
+    @Async("fcmMarketingPushExecutor")
+    fun sendMarketingPush(
+        title: String,
+        body: String,
+        deepLink: String? = null,
+        dryRun: Boolean = false,
+    ) {
+        val settings = notificationSettingRepository.findAllByIsMarketingPushEnabledTrue()
+        val targetSettings = if (isNightTime()) settings.filter { it.isNightPushEnabled } else settings
+        if (targetSettings.isEmpty()) return
+
+        val tokens = fcmTokenRepository.findByUserIdIn(targetSettings.map { it.userId })
+        fcmPushService.sendMulticast(tokens, title, body, deepLink, dryRun)
+    }
+
+    private fun isNightTime(): Boolean {
+        val hour = LocalTime.now(clock).hour
+        return hour >= NIGHT_START_HOUR || hour < NIGHT_END_HOUR
+    }
+}

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationService.kt
@@ -41,7 +41,7 @@ class NotificationService(
             notificationRepository.findById(notificationId)
                 ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "알림을 찾을 수 없습니다.")
 
-        require(notification.userId == userId) { "본인의 알림만 읽음 처리할 수 있습니다." }
+        if (notification.userId != userId) throw GlobalException(GlobalErrorCode.FORBIDDEN, "본인의 알림만 읽음 처리할 수 있습니다.")
 
         notification.markAsRead()
         notificationRepository.save(notification)
@@ -80,6 +80,7 @@ class NotificationService(
         }
         val deepLink = type.makeDeepLink(allParams)
         saved.deepLink = deepLink
+        notificationRepository.save(saved)
 
         // 3. FCM 푸시 전송 (커밋 이후 이벤트로 발송)
         if (notificationSettingService.shouldSendPush(targetUserId, type)) {

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/NotificationSettingService.kt
@@ -1,29 +1,15 @@
 package com.yapp.love.application.notification
 
-import com.yapp.love.application.notification.port.FcmPushService
-import com.yapp.love.domain.notification.FcmTokenRepository
 import com.yapp.love.domain.notification.NotificationSettingRepository
 import com.yapp.love.domain.notification.model.NotificationSetting
 import com.yapp.love.domain.notification.model.NotificationType
-import com.yapp.love.globalutils.exception.GlobalErrorCode
-import com.yapp.love.globalutils.exception.GlobalException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Clock
-import java.time.LocalTime
 
 @Service
 class NotificationSettingService(
     private val notificationSettingRepository: NotificationSettingRepository,
-    private val fcmTokenRepository: FcmTokenRepository,
-    private val fcmPushService: FcmPushService,
-    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    companion object {
-        private const val NIGHT_START_HOUR = 21
-        private const val NIGHT_END_HOUR = 8
-    }
-
     @Transactional
     fun initSetting(
         userId: Long,
@@ -55,18 +41,7 @@ class NotificationSettingService(
     fun updateMarketingPush(userId: Long, enabled: Boolean): NotificationSetting {
         val setting = findByUserId(userId)
         setting.updateMarketingPush(enabled)
-        notificationSettingRepository.save(setting)
-
-        val tokens = fcmTokenRepository.findByUserId(userId).map { it.token }
-        tokens.forEach { token ->
-            if (enabled) {
-                fcmPushService.subscribeToTopic(token, FcmTokenService.MARKETING_TOPIC)
-            } else {
-                fcmPushService.unsubscribeFromTopic(token, FcmTokenService.MARKETING_TOPIC)
-            }
-        }
-
-        return setting
+        return notificationSettingRepository.save(setting)
     }
 
     @Transactional
@@ -84,23 +59,18 @@ class NotificationSettingService(
             else -> {}
         }
 
-        if (isNightTime() && !setting.isNightPushEnabled) return false
-
         return true
     }
 
     private fun findByUserId(userId: Long): NotificationSetting {
         return notificationSettingRepository.findByUserId(userId)
-            ?: notificationSettingRepository.save(NotificationSetting.create(
-                userId = userId,
-                isPokePushEnabled = false,
-                isMarketingPushEnabled = false,
-                isNightPushEnabled = false,
-            ))
-    }
-
-    private fun isNightTime(): Boolean {
-        val hour = LocalTime.now(clock).hour
-        return hour >= NIGHT_START_HOUR || hour < NIGHT_END_HOUR
+            ?: notificationSettingRepository.save(
+                NotificationSetting.create(
+                    userId = userId,
+                    isPokePushEnabled = false,
+                    isMarketingPushEnabled = false,
+                    isNightPushEnabled = false,
+                ),
+            )
     }
 }

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/port/FcmPushService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/port/FcmPushService.kt
@@ -1,21 +1,18 @@
 package com.yapp.love.application.notification.port
 
+import com.yapp.love.domain.notification.model.FcmToken
+
 interface FcmPushService {
-    fun sendPushToUser(
-        userId: Long,
+    fun sendMulticast(
+        tokens: List<FcmToken>,
         title: String,
         body: String,
         deepLink: String? = null,
+        dryRun: Boolean = false,
     )
 
-    fun subscribeToTopic(token: String, topic: String)
-
-    fun unsubscribeFromTopic(token: String, topic: String)
-
-    fun unsubscribeFromTopicOrThrow(token: String, topic: String)
-
-    fun sendToTopic(
-        topic: String,
+    fun sendPushToUser(
+        userId: Long,
         title: String,
         body: String,
         deepLink: String? = null,

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/FcmTokenServiceTest.kt
@@ -1,11 +1,7 @@
 package com.yapp.love.application.notification
 
-import com.yapp.love.application.notification.port.FcmPushService
 import com.yapp.love.domain.notification.FcmTokenRepository
 import com.yapp.love.domain.notification.model.FcmToken
-import com.yapp.love.domain.notification.model.NotificationSetting
-import com.yapp.love.globalutils.exception.GlobalException
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
@@ -13,13 +9,9 @@ import io.mockk.*
 class FcmTokenServiceTest : DescribeSpec({
 
     val fcmTokenRepository = mockk<FcmTokenRepository>()
-    val fcmPushService = mockk<FcmPushService>(relaxed = true)
-    val notificationSettingService = mockk<NotificationSettingService>(relaxed = true)
 
     val fcmTokenService = FcmTokenService(
         fcmTokenRepository = fcmTokenRepository,
-        fcmPushService = fcmPushService,
-        notificationSettingService = notificationSettingService,
     )
 
     val userId = 1L
@@ -31,7 +23,6 @@ class FcmTokenServiceTest : DescribeSpec({
         every { fcmTokenRepository.findByDeviceIdAndUserIdNot(any(), any()) } returns emptyList()
         every { fcmTokenRepository.deleteAll(any()) } just Runs
         every { fcmTokenRepository.deleteByTokenAndUserIdNot(any(), any()) } just Runs
-        every { notificationSettingService.getSetting(any()) } returns NotificationSetting.create(userId = userId, isMarketingPushEnabled = true)
     }
 
     describe("registerToken") {
@@ -71,7 +62,7 @@ class FcmTokenServiceTest : DescribeSpec({
     describe("registerToken - 계정 전환") {
 
         context("같은 기기에 다른 유저의 토큰이 존재하는 경우") {
-            it("이전 유저의 토큰을 unsubscribe 후 삭제한다") {
+            it("이전 유저의 토큰을 삭제한다") {
                 val otherUserId = 99L
                 val oldToken = FcmToken.create(userId = otherUserId, token = "old-token", deviceId = deviceId)
                 every { fcmTokenRepository.findByDeviceIdAndUserIdNot(deviceId, userId) } returns listOf(oldToken)
@@ -80,51 +71,7 @@ class FcmTokenServiceTest : DescribeSpec({
 
                 fcmTokenService.registerToken(userId, token, deviceId)
 
-                verifyOrder {
-                    fcmPushService.unsubscribeFromTopic(oldToken.token, FcmTokenService.MARKETING_TOPIC)
-                    fcmTokenRepository.deleteAll(listOf(oldToken))
-                }
-            }
-        }
-    }
-
-    describe("registerToken - 마케팅 구독") {
-
-        beforeEach {
-            every { fcmTokenRepository.findByUserIdAndDeviceId(userId, deviceId) } returns null
-            every { fcmTokenRepository.save(any()) } answers { firstArg() }
-        }
-
-        context("마케팅 푸시가 켜져 있는 경우") {
-            it("마케팅 토픽을 구독한다") {
-                every { notificationSettingService.getSetting(userId) } returns
-                    NotificationSetting.create(userId = userId, isMarketingPushEnabled = true)
-
-                fcmTokenService.registerToken(userId, token, deviceId)
-
-                verify(exactly = 1) { fcmPushService.subscribeToTopic(token, FcmTokenService.MARKETING_TOPIC) }
-            }
-        }
-
-        context("마케팅 푸시가 꺼져 있는 경우") {
-            it("마케팅 토픽을 구독하지 않는다") {
-                every { notificationSettingService.getSetting(userId) } returns
-                    NotificationSetting.create(userId = userId, isMarketingPushEnabled = false)
-
-                fcmTokenService.registerToken(userId, token, deviceId)
-
-                verify(exactly = 0) { fcmPushService.subscribeToTopic(any(), any()) }
-            }
-        }
-
-        context("알림 설정이 존재하지 않는 경우") {
-            it("기본값 false로 처리하여 마케팅 토픽을 구독하지 않는다") {
-                every { notificationSettingService.getSetting(userId) } returns
-                    NotificationSetting.create(userId = userId, isMarketingPushEnabled = false)
-
-                fcmTokenService.registerToken(userId, token, deviceId)
-
-                verify(exactly = 0) { fcmPushService.subscribeToTopic(any(), any()) }
+                verify { fcmTokenRepository.deleteAll(listOf(oldToken)) }
             }
         }
     }
@@ -137,37 +84,19 @@ class FcmTokenServiceTest : DescribeSpec({
 
                 fcmTokenService.deleteToken(userId, token)
 
-                verify(exactly = 0) { fcmPushService.unsubscribeFromTopicOrThrow(any(), any()) }
                 verify(exactly = 0) { fcmTokenRepository.delete(any()) }
             }
         }
 
         context("토큰이 존재하는 경우") {
-            val fcmToken = FcmToken.create(userId = userId, token = token, deviceId = deviceId)
-
-            it("unsubscribe 후 토큰을 삭제한다") {
+            it("토큰을 삭제한다") {
+                val fcmToken = FcmToken.create(userId = userId, token = token, deviceId = deviceId)
                 every { fcmTokenRepository.findByUserIdAndToken(userId, token) } returns fcmToken
                 every { fcmTokenRepository.delete(fcmToken) } just Runs
 
                 fcmTokenService.deleteToken(userId, token)
 
-                verifyOrder {
-                    fcmPushService.unsubscribeFromTopicOrThrow(token, FcmTokenService.MARKETING_TOPIC)
-                    fcmTokenRepository.delete(fcmToken)
-                }
-            }
-
-            it("unsubscribe 실패 시 예외를 던지고 토큰을 삭제하지 않는다") {
-                every { fcmTokenRepository.findByUserIdAndToken(userId, token) } returns fcmToken
-                every { fcmPushService.unsubscribeFromTopicOrThrow(any(), any()) } throws GlobalException(
-                    com.yapp.love.globalutils.exception.GlobalErrorCode.FCM_UNSUBSCRIBE_FAILED
-                )
-
-                shouldThrow<GlobalException> {
-                    fcmTokenService.deleteToken(userId, token)
-                }
-
-                verify(exactly = 0) { fcmTokenRepository.delete(any()) }
+                verify { fcmTokenRepository.delete(fcmToken) }
             }
         }
     }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/MarketingPushServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/MarketingPushServiceTest.kt
@@ -1,0 +1,121 @@
+package com.yapp.love.application.notification
+
+import com.yapp.love.application.notification.port.FcmPushService
+import com.yapp.love.domain.notification.FcmTokenRepository
+import com.yapp.love.domain.notification.NotificationSettingRepository
+import com.yapp.love.domain.notification.model.FcmToken
+import com.yapp.love.domain.notification.model.NotificationSetting
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.*
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class MarketingPushServiceTest : DescribeSpec({
+
+    val notificationSettingRepository = mockk<NotificationSettingRepository>()
+    val fcmTokenRepository = mockk<FcmTokenRepository>()
+    val fcmPushService = mockk<FcmPushService>(relaxed = true)
+
+    fun serviceWithHour(hour: Int): MarketingPushService {
+        val clock = Clock.fixed(
+            Instant.parse("2026-01-01T${hour.toString().padStart(2, '0')}:00:00Z")
+                .minusSeconds(9 * 3600), // UTC → KST(+9) 보정
+            ZoneId.of("Asia/Seoul"),
+        )
+        return MarketingPushService(
+            notificationSettingRepository = notificationSettingRepository,
+            fcmTokenRepository = fcmTokenRepository,
+            fcmPushService = fcmPushService,
+            clock = clock,
+        )
+    }
+
+    beforeEach {
+        clearAllMocks()
+    }
+
+    describe("sendMarketingPush") {
+
+        context("낮 시간대(09시)인 경우") {
+            val service = serviceWithHour(9)
+
+            it("마케팅 동의 유저 전체에게 전송한다") {
+                val settings = listOf(
+                    NotificationSetting.create(userId = 1L, isMarketingPushEnabled = true, isNightPushEnabled = false),
+                    NotificationSetting.create(userId = 2L, isMarketingPushEnabled = true, isNightPushEnabled = true),
+                )
+                val tokens = listOf(
+                    FcmToken.create(userId = 1L, token = "token1", deviceId = "device1"),
+                    FcmToken.create(userId = 2L, token = "token2", deviceId = "device2"),
+                )
+                every { notificationSettingRepository.findAllByIsMarketingPushEnabledTrue() } returns settings
+                every { fcmTokenRepository.findByUserIdIn(listOf(1L, 2L)) } returns tokens
+
+                service.sendMarketingPush(title = "이벤트", body = "내용")
+
+                verify { fcmPushService.sendMulticast(tokens, "이벤트", "내용", null) }
+            }
+        }
+
+        context("야간 시간대(22시)인 경우") {
+            val service = serviceWithHour(22)
+
+            it("야간 푸시 허용 유저에게만 전송한다") {
+                val settings = listOf(
+                    NotificationSetting.create(userId = 1L, isMarketingPushEnabled = true, isNightPushEnabled = false),
+                    NotificationSetting.create(userId = 2L, isMarketingPushEnabled = true, isNightPushEnabled = true),
+                )
+                val tokens = listOf(
+                    FcmToken.create(userId = 2L, token = "token2", deviceId = "device2"),
+                )
+                every { notificationSettingRepository.findAllByIsMarketingPushEnabledTrue() } returns settings
+                every { fcmTokenRepository.findByUserIdIn(listOf(2L)) } returns tokens
+
+                service.sendMarketingPush(title = "이벤트", body = "내용")
+
+                verify { fcmPushService.sendMulticast(tokens, "이벤트", "내용", null) }
+            }
+
+            it("야간 허용 유저가 없으면 전송하지 않는다") {
+                val settings = listOf(
+                    NotificationSetting.create(userId = 1L, isMarketingPushEnabled = true, isNightPushEnabled = false),
+                )
+                every { notificationSettingRepository.findAllByIsMarketingPushEnabledTrue() } returns settings
+
+                service.sendMarketingPush(title = "이벤트", body = "내용")
+
+                verify(exactly = 0) { fcmPushService.sendMulticast(any(), any(), any(), any()) }
+            }
+        }
+
+        context("마케팅 동의 유저가 없는 경우") {
+            val service = serviceWithHour(9)
+
+            it("전송하지 않는다") {
+                every { notificationSettingRepository.findAllByIsMarketingPushEnabledTrue() } returns emptyList()
+
+                service.sendMarketingPush(title = "이벤트", body = "내용")
+
+                verify(exactly = 0) { fcmPushService.sendMulticast(any(), any(), any(), any()) }
+            }
+        }
+
+        context("deepLink가 있는 경우") {
+            val service = serviceWithHour(9)
+
+            it("deepLink를 포함하여 전송한다") {
+                val settings = listOf(
+                    NotificationSetting.create(userId = 1L, isMarketingPushEnabled = true),
+                )
+                val tokens = listOf(FcmToken.create(userId = 1L, token = "token1", deviceId = "device1"))
+                every { notificationSettingRepository.findAllByIsMarketingPushEnabledTrue() } returns settings
+                every { fcmTokenRepository.findByUserIdIn(listOf(1L)) } returns tokens
+
+                service.sendMarketingPush(title = "이벤트", body = "내용", deepLink = "love://event")
+
+                verify { fcmPushService.sendMulticast(tokens, "이벤트", "내용", "love://event") }
+            }
+        }
+    }
+})

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationServiceTest.kt
@@ -30,6 +30,20 @@ class NotificationServiceTest : DescribeSpec({
         clearAllMocks()
     }
 
+    describe("hasUnread") {
+        it("읽지 않은 알림이 있으면 true를 반환한다") {
+            every { notificationRepository.existsUnreadByUserId(userId) } returns true
+
+            notificationService.hasUnread(userId) shouldBe true
+        }
+
+        it("읽지 않은 알림이 없으면 false를 반환한다") {
+            every { notificationRepository.existsUnreadByUserId(userId) } returns false
+
+            notificationService.hasUnread(userId) shouldBe false
+        }
+    }
+
     describe("getNotifications") {
         it("첫 페이지 조회 시 lastId 없이 호출하고 hasNext를 반환한다") {
             val notifications = (1..21).map {
@@ -90,7 +104,7 @@ class NotificationServiceTest : DescribeSpec({
         }
 
         context("다른 사용자의 알림인 경우") {
-            it("예외가 발생한다") {
+            it("FORBIDDEN 예외가 발생한다") {
                 val otherUserNotification = Notification.create(
                     userId = 999L,
                     type = NotificationType.POKE,
@@ -99,7 +113,7 @@ class NotificationServiceTest : DescribeSpec({
                 )
                 every { notificationRepository.findById(notificationId) } returns otherUserNotification
 
-                shouldThrow<IllegalArgumentException> {
+                shouldThrow<GlobalException> {
                     notificationService.markAsRead(userId, notificationId)
                 }
             }
@@ -139,7 +153,7 @@ class NotificationServiceTest : DescribeSpec({
                     deepLinkParams = mapOf("goalId" to "10"),
                 )
 
-                verify(exactly = 1) { notificationRepository.save(any()) }
+                verify(exactly = 2) { notificationRepository.save(any()) }
                 verify { eventPublisher.publishEvent(any<FcmPushEvent>()) }
             }
 
@@ -191,7 +205,7 @@ class NotificationServiceTest : DescribeSpec({
                     bodyArgs = arrayOf("철수"),
                 )
 
-                verify(exactly = 1) { notificationRepository.save(any()) }
+                verify(exactly = 2) { notificationRepository.save(any()) }
                 verify(exactly = 0) { eventPublisher.publishEvent(any<FcmPushEvent>()) }
             }
         }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationSettingServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/NotificationSettingServiceTest.kt
@@ -1,38 +1,19 @@
 package com.yapp.love.application.notification
 
-import com.yapp.love.application.notification.port.FcmPushService
-import com.yapp.love.domain.notification.FcmTokenRepository
 import com.yapp.love.domain.notification.NotificationSettingRepository
 import com.yapp.love.domain.notification.model.NotificationSetting
 import com.yapp.love.domain.notification.model.NotificationType
-import com.yapp.love.globalutils.exception.GlobalException
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
-import com.yapp.love.domain.notification.model.FcmToken
 
 class NotificationSettingServiceTest : DescribeSpec({
 
     val notificationSettingRepository = mockk<NotificationSettingRepository>()
-    val fcmTokenRepository = mockk<FcmTokenRepository>(relaxed = true)
-    val fcmPushService = mockk<FcmPushService>(relaxed = true)
 
-    fun serviceWithHour(hour: Int): NotificationSettingService {
-        val instant = Instant.parse("2024-01-01T${hour.toString().padStart(2, '0')}:00:00Z")
-        val clock = Clock.fixed(instant, ZoneId.of("UTC"))
-        return NotificationSettingService(
-            notificationSettingRepository = notificationSettingRepository,
-            fcmTokenRepository = fcmTokenRepository,
-            fcmPushService = fcmPushService,
-            clock = clock,
-        )
-    }
-
-    val service = serviceWithHour(14) // 낮 시간(14시) 기본값
+    val service = NotificationSettingService(
+        notificationSettingRepository = notificationSettingRepository,
+    )
 
     val userId = 1L
 
@@ -57,6 +38,31 @@ class NotificationSettingServiceTest : DescribeSpec({
             result.isMarketingPushEnabled shouldBe false
             result.isNightPushEnabled shouldBe true
             verify { notificationSettingRepository.save(any()) }
+        }
+
+        context("설정이 이미 존재하는 경우") {
+            it("기존 설정을 업데이트한다") {
+                val existing = NotificationSetting.create(
+                    userId = userId,
+                    isPokePushEnabled = false,
+                    isMarketingPushEnabled = false,
+                    isNightPushEnabled = false,
+                )
+                every { notificationSettingRepository.findByUserId(userId) } returns existing
+                every { notificationSettingRepository.save(any()) } answers { firstArg() }
+
+                val result = service.initSetting(
+                    userId = userId,
+                    isPokePushEnabled = true,
+                    isMarketingPushEnabled = true,
+                    isNightPushEnabled = true,
+                )
+
+                result.isPokePushEnabled shouldBe true
+                result.isMarketingPushEnabled shouldBe true
+                result.isNightPushEnabled shouldBe true
+                verify(exactly = 1) { notificationSettingRepository.save(any()) }
+            }
         }
     }
 
@@ -115,49 +121,11 @@ class NotificationSettingServiceTest : DescribeSpec({
             val setting = NotificationSetting.create(userId = userId, isMarketingPushEnabled = false)
             every { notificationSettingRepository.findByUserId(userId) } returns setting
             every { notificationSettingRepository.save(any()) } answers { firstArg() }
-            every { fcmTokenRepository.findByUserId(userId) } returns emptyList()
 
             val result = service.updateMarketingPush(userId, true)
 
             result.isMarketingPushEnabled shouldBe true
-        }
-
-        context("enabled = true이고 토큰이 있는 경우") {
-            it("모든 토큰을 마케팅 토픽에 구독한다") {
-                val setting = NotificationSetting.create(userId = userId, isMarketingPushEnabled = false)
-                val tokens = listOf(
-                    FcmToken.create(userId, "token-1", "device-1"),
-                    FcmToken.create(userId, "token-2", "device-2"),
-                )
-                every { notificationSettingRepository.findByUserId(userId) } returns setting
-                every { notificationSettingRepository.save(any()) } answers { firstArg() }
-                every { fcmTokenRepository.findByUserId(userId) } returns tokens
-
-                service.updateMarketingPush(userId, true)
-
-                verify(exactly = 1) { fcmPushService.subscribeToTopic("token-1", FcmTokenService.MARKETING_TOPIC) }
-                verify(exactly = 1) { fcmPushService.subscribeToTopic("token-2", FcmTokenService.MARKETING_TOPIC) }
-                verify(exactly = 0) { fcmPushService.unsubscribeFromTopic(any(), any()) }
-            }
-        }
-
-        context("enabled = false이고 토큰이 있는 경우") {
-            it("모든 토큰을 마케팅 토픽에서 구독 해제한다") {
-                val setting = NotificationSetting.create(userId = userId, isMarketingPushEnabled = true)
-                val tokens = listOf(
-                    FcmToken.create(userId, "token-1", "device-1"),
-                    FcmToken.create(userId, "token-2", "device-2"),
-                )
-                every { notificationSettingRepository.findByUserId(userId) } returns setting
-                every { notificationSettingRepository.save(any()) } answers { firstArg() }
-                every { fcmTokenRepository.findByUserId(userId) } returns tokens
-
-                service.updateMarketingPush(userId, false)
-
-                verify(exactly = 1) { fcmPushService.unsubscribeFromTopic("token-1", FcmTokenService.MARKETING_TOPIC) }
-                verify(exactly = 1) { fcmPushService.unsubscribeFromTopic("token-2", FcmTokenService.MARKETING_TOPIC) }
-                verify(exactly = 0) { fcmPushService.subscribeToTopic(any(), any()) }
-            }
+            verify { notificationSettingRepository.save(any()) }
         }
     }
 
@@ -192,56 +160,20 @@ class NotificationSettingServiceTest : DescribeSpec({
             }
         }
 
-        context("타입별 설정이 켜져 있고 야간이 아닌 경우") {
+        context("타입별 설정이 켜져 있는 경우") {
             it("true를 반환한다") {
-                val setting = NotificationSetting.create(
-                    userId = userId,
-                    isPokePushEnabled = true,
-                    isNightPushEnabled = false,
-                )
+                val setting = NotificationSetting.create(userId = userId, isPokePushEnabled = true)
                 every { notificationSettingRepository.findByUserId(userId) } returns setting
 
-                serviceWithHour(14).shouldSendPush(userId, NotificationType.POKE) shouldBe true
-            }
-        }
-
-        context("야간이고 야간 푸시가 꺼져 있는 경우") {
-            it("false를 반환한다") {
-                val setting = NotificationSetting.create(
-                    userId = userId,
-                    isPokePushEnabled = true,
-                    isNightPushEnabled = false,
-                )
-                every { notificationSettingRepository.findByUserId(userId) } returns setting
-
-                serviceWithHour(22).shouldSendPush(userId, NotificationType.POKE) shouldBe false
-            }
-        }
-
-        context("야간이지만 야간 푸시가 켜져 있는 경우") {
-            it("true를 반환한다") {
-                val setting = NotificationSetting.create(
-                    userId = userId,
-                    isPokePushEnabled = true,
-                    isNightPushEnabled = true,
-                )
-                every { notificationSettingRepository.findByUserId(userId) } returns setting
-
-                serviceWithHour(22).shouldSendPush(userId, NotificationType.POKE) shouldBe true
+                service.shouldSendPush(userId, NotificationType.POKE) shouldBe true
             }
         }
 
         context("GOAL_COMPLETED 등 타입별 제한이 없는 경우") {
-            it("설정이 존재하면 야간 여부에 따라 결정된다") {
-                val setting = NotificationSetting.create(
-                    userId = userId,
-                    isPokePushEnabled = false,
-                    isNightPushEnabled = true,
-                )
+            it("설정이 존재하면 true를 반환한다") {
+                val setting = NotificationSetting.create(userId = userId)
                 every { notificationSettingRepository.findByUserId(userId) } returns setting
 
-                // GOAL_COMPLETED는 타입별 제한이 없으므로 야간 설정만 체크
-                // isNightPushEnabled가 true이면 야간이어도 전송 가능
                 service.shouldSendPush(userId, NotificationType.GOAL_COMPLETED) shouldBe true
             }
         }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/event/NotificationEventListenerTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/event/NotificationEventListenerTest.kt
@@ -313,6 +313,30 @@ class NotificationEventListenerTest : DescribeSpec({
         }
     }
 
+    describe("handleFcmPush") {
+        it("FCM 푸시를 전송한다") {
+            val event = FcmPushEvent(userId = 1L, title = "제목", body = "내용", deepLink = "love://home")
+
+            listener.handleFcmPush(event)
+
+            verify {
+                fcmPushService.sendPushToUser(
+                    userId = 1L,
+                    title = "제목",
+                    body = "내용",
+                    deepLink = "love://home",
+                )
+            }
+        }
+
+        it("예외 발생 시 메서드가 정상 종료된다") {
+            val event = FcmPushEvent(userId = 1L, title = "제목", body = "내용", deepLink = "love://home")
+            every { fcmPushService.sendPushToUser(any(), any(), any(), any()) } throws RuntimeException("FCM 오류")
+
+            listener.handleFcmPush(event)
+        }
+    }
+
     describe("handleReactionCreated") {
         it("포토로그 소유자에게 REACTION 알림을 전송한다") {
             val event = ReactionCreatedEvent(

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/notification/FcmTokenRepository.kt
@@ -7,6 +7,8 @@ interface FcmTokenRepository {
 
     fun findByUserId(userId: Long): List<FcmToken>
 
+    fun findByUserIdIn(userIds: List<Long>): List<FcmToken>
+
     fun findByUserIdAndDeviceId(
         userId: Long,
         deviceId: String,

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/notification/NotificationSettingRepository.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/notification/NotificationSettingRepository.kt
@@ -6,4 +6,6 @@ interface NotificationSettingRepository {
     fun save(notificationSetting: NotificationSetting): NotificationSetting
 
     fun findByUserId(userId: Long): NotificationSetting?
+
+    fun findAllByIsMarketingPushEnabledTrue(): List<NotificationSetting>
 }

--- a/love/infrastructure/build.gradle
+++ b/love/infrastructure/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation("com.google.api-client:google-api-client:2.8.1")
 
     // Firebase
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
 
     // ShedLock
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.0.2'

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/fcm/FcmPushServiceImpl.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/fcm/FcmPushServiceImpl.kt
@@ -4,11 +4,11 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingException
 import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
 import com.google.firebase.messaging.Notification
 import com.yapp.love.application.notification.port.FcmPushService
 import com.yapp.love.domain.notification.FcmTokenRepository
-import com.yapp.love.globalutils.exception.GlobalErrorCode
-import com.yapp.love.globalutils.exception.GlobalException
+import com.yapp.love.domain.notification.model.FcmToken
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
@@ -19,6 +19,53 @@ class FcmPushServiceImpl(
     private val firebaseMessaging: FirebaseMessaging,
     private val fcmTokenRepository: FcmTokenRepository,
 ) : FcmPushService {
+    override fun sendMulticast(
+        tokens: List<FcmToken>,
+        title: String,
+        body: String,
+        deepLink: String?,
+        dryRun: Boolean,
+    ) {
+        if (tokens.isEmpty()) return
+
+        val notification = Notification.builder()
+            .setTitle(title)
+            .setBody(body)
+            .build()
+
+        tokens.chunked(100).forEach { chunk ->
+            val multicastMessage =
+                MulticastMessage.builder()
+                    .addAllTokens(chunk.map { it.token })
+                    .setNotification(notification)
+                    .apply { if (deepLink != null) putData("deepLink", deepLink) }
+                    .build()
+            try {
+                val response = firebaseMessaging.sendEachForMulticast(multicastMessage, dryRun)
+                logger.info { "멀티캐스트 전송: success=${response.successCount}, failure=${response.failureCount}" }
+                response.responses.forEachIndexed { index, sendResponse ->
+                    if (!sendResponse.isSuccessful) {
+                        val errorCode = sendResponse.exception?.messagingErrorCode
+                        if (errorCode == MessagingErrorCode.UNREGISTERED) {
+                            try {
+                                fcmTokenRepository.delete(chunk[index])
+                                logger.info { "만료 토큰 삭제: token=${chunk[index].token}" }
+                            } catch (e: Exception) {
+                                logger.error(e) { "만료 토큰 삭제 실패: token=${chunk[index].token}" }
+                            }
+                        } else {
+                            logger.error(sendResponse.exception) {
+                                "멀티캐스트 개별 전송 실패: token=${chunk[index].token}, errorCode=$errorCode"
+                            }
+                        }
+                    }
+                }
+            } catch (e: FirebaseMessagingException) {
+                logger.error(e) { "멀티캐스트 전송 실패: chunkSize=${chunk.size}, errorCode=${e.messagingErrorCode}" }
+            }
+        }
+    }
+
     override fun sendPushToUser(
         userId: Long,
         title: String,
@@ -44,59 +91,6 @@ class FcmPushServiceImpl(
                     logger.error(e) { "FCM 전송 실패: userId=$userId, token=${fcmToken.token}" }
                 }
             }
-        }
-    }
-
-    override fun sendToTopic(
-        topic: String,
-        title: String,
-        body: String,
-        deepLink: String?,
-    ) {
-        try {
-            val message =
-                Message.builder()
-                    .setTopic(topic)
-                    .setNotification(
-                        Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .build(),
-                    )
-                    .apply { if (deepLink != null) putData("deepLink", deepLink) }
-                    .build()
-            val response = firebaseMessaging.send(message)
-            logger.info { "토픽 푸시 전송 성공: topic=$topic, messageId=$response" }
-        } catch (e: FirebaseMessagingException) {
-            logger.error(e) { "토픽 푸시 전송 실패: topic=$topic" }
-        }
-    }
-
-    override fun subscribeToTopic(token: String, topic: String) {
-        try {
-            firebaseMessaging.subscribeToTopic(listOf(token), topic)
-            logger.info { "토픽 구독 완료: token=$token, topic=$topic" }
-        } catch (e: FirebaseMessagingException) {
-            logger.error(e) { "토픽 구독 실패: token=$token, topic=$topic" }
-        }
-    }
-
-    override fun unsubscribeFromTopic(token: String, topic: String) {
-        try {
-            firebaseMessaging.unsubscribeFromTopic(listOf(token), topic)
-            logger.info { "토픽 구독 해제 완료: token=$token, topic=$topic" }
-        } catch (e: FirebaseMessagingException) {
-            logger.error(e) { "토픽 구독 해제 실패: token=$token, topic=$topic" }
-        }
-    }
-
-    override fun unsubscribeFromTopicOrThrow(token: String, topic: String) {
-        try {
-            firebaseMessaging.unsubscribeFromTopic(listOf(token), topic)
-            logger.info { "토픽 구독 해제 완료: token=$token, topic=$topic" }
-        } catch (e: FirebaseMessagingException) {
-            logger.error(e) { "토픽 구독 해제 실패: token=$token, topic=$topic" }
-            throw GlobalException(GlobalErrorCode.FCM_UNSUBSCRIBE_FAILED)
         }
     }
 

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/fcm/config/AsyncConfig.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/fcm/config/AsyncConfig.kt
@@ -13,13 +13,26 @@ private val logger = KotlinLogging.logger {}
 @EnableAsync
 @Configuration
 class AsyncConfig : AsyncConfigurer {
+    // current spec : 0.5 vCPU, 1GB RAM Fargate
     @Bean(name = ["fcmTaskExecutor"])
     fun fcmTaskExecutor(): ThreadPoolTaskExecutor {
         return ThreadPoolTaskExecutor().apply {
             corePoolSize = 2
-            maxPoolSize = 10
-            queueCapacity = 500
+            maxPoolSize = 4  // 0.5 vCPU에서 I/O bound 작업 기준
+            queueCapacity = 100
             setThreadNamePrefix("fcm-async-")
+            initialize()
+        }
+    }
+
+    @Bean(name = ["fcmMarketingPushExecutor"])
+    fun fcmMarketingPushExecutor(): ThreadPoolTaskExecutor {
+        // 마케팅 발송 특성상 동시에 여러 요청이 들어올 경우가 적음
+        return ThreadPoolTaskExecutor().apply {
+            corePoolSize = 2 // 500개씩 쪼개서 보내서 스레드를 오래 점유하는 작업
+            maxPoolSize = 2
+            queueCapacity = 5
+            setThreadNamePrefix("marketing-push-")
             initialize()
         }
     }

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/FcmTokenJpaRepository.kt
@@ -17,6 +17,8 @@ interface FcmTokenJpaRepositoryInterface : JpaRepository<FcmToken, Long> {
     
     fun findByDeviceIdAndUserIdNot(deviceId: String, userId: Long): List<FcmToken>
 
+    fun findByUserIdIn(userIds: List<Long>): List<FcmToken>
+
     fun deleteByTokenAndUserIdNot(token: String, userId: Long)
 
     fun deleteByUserId(userId: Long)
@@ -51,6 +53,10 @@ class FcmTokenJpaRepository(
 
     override fun findByDeviceIdAndUserIdNot(deviceId: String, userId: Long): List<FcmToken> {
         return jpaRepository.findByDeviceIdAndUserIdNot(deviceId, userId)
+    }
+
+    override fun findByUserIdIn(userIds: List<Long>): List<FcmToken> {
+        return jpaRepository.findByUserIdIn(userIds)
     }
 
     override fun deleteAll(fcmTokens: List<FcmToken>) {

--- a/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/NotificationSettingJpaRepository.kt
+++ b/love/infrastructure/src/main/kotlin/com/yapp/love/infrastructure/persistence/notification/NotificationSettingJpaRepository.kt
@@ -10,4 +10,6 @@ interface NotificationSettingJpaRepository :
     NotificationSettingRepository,
     JpaRepository<NotificationSetting, Long> {
     override fun findByUserId(userId: Long): NotificationSetting?
+
+    override fun findAllByIsMarketingPushEnabledTrue(): List<NotificationSetting>
 }

--- a/love/web/src/main/kotlin/com/yapp/love/web/admin/AdminNotificationController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/admin/AdminNotificationController.kt
@@ -1,7 +1,6 @@
 package com.yapp.love.web.admin
 
-import com.yapp.love.application.notification.FcmTokenService
-import com.yapp.love.application.notification.port.FcmPushService
+import com.yapp.love.application.notification.MarketingPushService
 import com.yapp.love.globalutils.exception.GlobalErrorCode
 import com.yapp.love.globalutils.exception.GlobalException
 import com.yapp.love.web.admin.dto.MarketingPushRequest
@@ -19,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/admin/notifications")
 class AdminNotificationController(
-    private val fcmPushService: FcmPushService,
+    private val marketingPushService: MarketingPushService,
     @Value("\${admin.secret}")
     private val adminSecret: String,
 ) {
@@ -32,11 +31,11 @@ class AdminNotificationController(
             throw GlobalException(GlobalErrorCode.UNAUTHORIZED, "인증되지 않은 요청입니다.")
         }
 
-        fcmPushService.sendToTopic(
-            topic = FcmTokenService.MARKETING_TOPIC,
+        marketingPushService.sendMarketingPush(
             title = request.title,
             body = request.body,
             deepLink = request.deepLink,
+            dryRun = request.dryRun,
         )
     }
 }

--- a/love/web/src/main/kotlin/com/yapp/love/web/admin/dto/MarketingPushRequest.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/admin/dto/MarketingPushRequest.kt
@@ -4,4 +4,5 @@ data class MarketingPushRequest(
     val title: String,
     val body: String,
     val deepLink: String? = null,
+    val dryRun: Boolean = false,
 )

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationApiSpec.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationApiSpec.kt
@@ -72,8 +72,7 @@ annotation class RegisterFcmTokenApiSpec
 @Retention(AnnotationRetention.RUNTIME)
 @Operation(
     summary = "FCM 토큰 삭제",
-    description = "로그아웃 시 디바이스 FCM 토큰을 삭제하고 마케팅 topic 구독을 해제합니다. 토큰이 존재하지 않으면 무시됩니다.\n\n" +
-        "FCM topic 구독 해제 실패 시 500이 반환되며, 이 경우 DB 삭제도 롤백됩니다. 재시도해주세요.",
+    description = "로그아웃 시 디바이스 FCM 토큰을 삭제합니다. 토큰이 존재하지 않으면 무시됩니다.",
 )
 @ApiResponses(
     value = [
@@ -95,21 +94,6 @@ annotation class RegisterFcmTokenApiSpec
                         ExampleObject(
                             name = "토큰 만료",
                             value = """{"status": 401, "code": "G4011", "message": "토큰이 만료되었습니다."}""",
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        ApiResponse(
-            responseCode = "500",
-            description = "FCM 구독 해제 실패",
-            content = [
-                Content(
-                    schema = Schema(implementation = ErrorResponse::class),
-                    examples = [
-                        ExampleObject(
-                            name = "FCM 구독 해제 실패",
-                            value = """{"status": 500, "code": "G5001", "message": "FCM 토픽 구독 해제에 실패했습니다. 잠시 후 다시 시도해주세요."}""",
                         ),
                     ],
                 ),


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #88 

## 💻 작업 내용
- 마케팅 푸시 전송 방식을 FCM 토픽 구독 기반에서 직접 멀티캐스트로 전환 (야간 마케팅 푸쉬 수신 설정에 따라 발송 여부를 달리하기 위함)
- sendEachForMulticast 방식으로 변경
- `@Async("fcmMarketingPushExecutor")`로 비동기 처리
  - `dryRun` 파라미터 지원 (FCM `validateOnly` — 실제 푸시 없이 검증)

## 🧪 참고
- Firebase Admin SDK `9.2.0` → `9.5.0` (내부 스레드풀 unbounded queue 버그 수정, 최대 100스레드 제한)