### PR TITLE
fix: 프로필 업데이트 시 온보딩 상태의 멱등성을 보장하도록 수정

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/onboarding/OnboardingService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/onboarding/OnboardingService.kt
@@ -87,7 +87,7 @@ class OnboardingService(
         val coupleInfo = coupleInfoRepository.findByUserId(userId)
             ?: throw GlobalException(GlobalErrorCode.COUPLE_NOT_FOUND, "커플 정보를 찾을 수 없습니다.")
 
-        updateOnboardingStatus(userId, coupleInfo)
+        updateOnboardingStatus(userId, coupleInfo, OnboardingStatus.PROFILE_SETUP)
     }
 
     @Transactional
@@ -106,13 +106,13 @@ class OnboardingService(
         coupleInfo.setAnniversary(anniversaryDate)
         coupleInfoRepository.save(coupleInfo)
 
-        updateOnboardingStatus(userId, coupleInfo)
+        updateOnboardingStatus(userId, coupleInfo, OnboardingStatus.ANNIVERSARY_SETUP)
     }
 
-    private fun updateOnboardingStatus(userId: Long, coupleInfo: CoupleInfo) {
+    private fun updateOnboardingStatus(userId: Long, coupleInfo: CoupleInfo, expectedStatus: OnboardingStatus? = null) {
         val onboardingInfo = onboardingInfoRepository.findByUserId(userId)
             ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "온보딩 정보를 찾을 수 없습니다.")
-        onboardingInfo.updateStatus(coupleInfo)
+        onboardingInfo.updateStatus(coupleInfo, expectedStatus)
         onboardingInfoRepository.save(onboardingInfo)
     }
 

--- a/love/domain/src/main/kotlin/com/yapp/love/domain/onboarding/model/Onboarding.kt
+++ b/love/domain/src/main/kotlin/com/yapp/love/domain/onboarding/model/Onboarding.kt
@@ -49,8 +49,10 @@ class UserOnboardingInfo(
     var completedAt: LocalDateTime? = null,
 ) : BaseEntity() {
 
-    fun updateStatus(coupleInfo: CoupleInfo) {
+    fun updateStatus(coupleInfo: CoupleInfo, expectedStatus: OnboardingStatus? = null) {
         check(status != OnboardingStatus.COMPLETED) { "이미 온보딩이 완료되었습니다." }
+
+        if (expectedStatus != null && status != expectedStatus) return
 
         if (coupleInfo.anniversaryDate != null && status == OnboardingStatus.PROFILE_SETUP) {
             status = OnboardingStatus.COMPLETED


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #94 
- TWI-44

## 💻 작업 내용
- 온보딩 상태 업데이트 시, 예상된 상태에 대한 파라미터 추가
- 현재 상태가 예상된 상태와 다른 경우 경우 no-op 처리 (`status.next()`로 인한 과진행 방지)

## 🧪 참고