### PR TITLE
feat: 리액션 해제 기능 구현

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
@@ -181,20 +181,7 @@ class PhotologService(
         userId: Long,
         reaction: ReactionType,
     ): ReactionInfo {
-        val photolog =
-            photologRepository.findById(photologId)
-                ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "인증샷을 찾을 수 없습니다.")
-
-        if (photolog.userId == userId) {
-            throw GlobalException(GlobalErrorCode.FORBIDDEN, "자신의 인증샷에는 리액션을 남길 수 없습니다.")
-        }
-
-        val coupleInfo = coupleService.getCoupleInfoByUserId(userId)
-        val partnerUserId = coupleService.getPartnerUserIdByCoupleInfo(coupleInfo, userId)
-
-        if (photolog.userId != partnerUserId) {
-            throw GlobalException(GlobalErrorCode.FORBIDDEN, "상대방의 인증샷에만 리액션을 남길 수 있습니다.")
-        }
+        val photolog = findPartnerPhotolog(photologId, userId)
 
         photolog.reaction = reaction
         photologRepository.save(photolog)
@@ -212,6 +199,39 @@ class PhotologService(
             photologId = photolog.id!!,
             reaction = reaction,
         )
+    }
+
+    @Transactional
+    fun removeReaction(
+        photologId: Long,
+        userId: Long,
+    ) {
+        val photolog = findPartnerPhotolog(photologId, userId)
+
+        photolog.reaction = null
+        photologRepository.save(photolog)
+    }
+
+    private fun findPartnerPhotolog(
+        photologId: Long,
+        userId: Long,
+    ): Photolog {
+        val photolog =
+            photologRepository.findById(photologId)
+                ?: throw GlobalException(GlobalErrorCode.NOT_FOUND, "인증샷을 찾을 수 없습니다.")
+
+        if (photolog.userId == userId) {
+            throw GlobalException(GlobalErrorCode.FORBIDDEN, "자신의 인증샷에는 리액션을 남길 수 없습니다.")
+        }
+
+        val coupleInfo = coupleService.getCoupleInfoByUserId(userId)
+        val partnerUserId = coupleService.getPartnerUserIdByCoupleInfo(coupleInfo, userId)
+
+        if (photolog.userId != partnerUserId) {
+            throw GlobalException(GlobalErrorCode.FORBIDDEN, "상대방의 인증샷에만 리액션을 남길 수 있습니다.")
+        }
+
+        return photolog
     }
 
     @Transactional

--- a/love/application/src/test/kotlin/com/yapp/love/application/photolog/PhotologServiceTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/photolog/PhotologServiceTest.kt
@@ -167,5 +167,129 @@ class PhotologServiceTest : DescribeSpec({
             }
         }
     }
+
+    describe("removeReaction") {
+
+        val myUserId = 1L
+        val partnerUserId = 2L
+        val coupleId = 100L
+        val photologId = 10L
+
+        val coupleInfo =
+            CoupleInfo(
+                id = coupleId,
+                user1Id = myUserId,
+                user2Id = partnerUserId,
+                inviteCodeId = 1L,
+                anniversaryDate = LocalDate.of(2024, 1, 1),
+            )
+
+        fun createPhotolog(
+            userId: Long,
+            reaction: ReactionType? = null,
+        ) = Photolog(
+            id = photologId,
+            goalId = 200L,
+            userId = userId,
+            verificationDate = LocalDate.of(2026, 2, 9),
+            uploadedAt = Instant.now(),
+            fileName = "test.jpg",
+        ).also { it.reaction = reaction }
+
+        context("상대방 포토로그의 리액션을 해제하는 경우") {
+
+            it("리액션이 정상적으로 해제되어야 함") {
+                // given
+                val partnerPhotolog = createPhotolog(partnerUserId, ReactionType.ICON_HAPPY)
+
+                every { photologRepository.findById(photologId) } returns partnerPhotolog
+                every { coupleService.getCoupleInfoByUserId(myUserId) } returns coupleInfo
+                every { coupleService.getPartnerUserIdByCoupleInfo(coupleInfo, myUserId) } returns partnerUserId
+                every { photologRepository.save(partnerPhotolog) } returns partnerPhotolog
+
+                // when
+                photologService.removeReaction(photologId, myUserId)
+
+                // then
+                partnerPhotolog.reaction shouldBe null
+                verify(exactly = 1) { photologRepository.save(partnerPhotolog) }
+            }
+
+            it("이미 리액션이 없는 상태에서도 정상 처리되어야 함") {
+                // given
+                val partnerPhotolog = createPhotolog(partnerUserId, reaction = null)
+
+                every { photologRepository.findById(photologId) } returns partnerPhotolog
+                every { coupleService.getCoupleInfoByUserId(myUserId) } returns coupleInfo
+                every { coupleService.getPartnerUserIdByCoupleInfo(coupleInfo, myUserId) } returns partnerUserId
+                every { photologRepository.save(partnerPhotolog) } returns partnerPhotolog
+
+                // when
+                photologService.removeReaction(photologId, myUserId)
+
+                // then
+                partnerPhotolog.reaction shouldBe null
+                verify(exactly = 1) { photologRepository.save(partnerPhotolog) }
+            }
+        }
+
+        context("자신의 포토로그에 리액션 해제를 시도하는 경우") {
+
+            it("FORBIDDEN 예외가 발생해야 함") {
+                // given
+                val myPhotolog = createPhotolog(myUserId, ReactionType.ICON_HAPPY)
+
+                every { photologRepository.findById(photologId) } returns myPhotolog
+
+                // when & then
+                val exception =
+                    shouldThrow<GlobalException> {
+                        photologService.removeReaction(photologId, myUserId)
+                    }
+
+                exception.getCustomMessage() shouldBe "자신의 인증샷에는 리액션을 남길 수 없습니다."
+                verify(exactly = 0) { photologRepository.save(any()) }
+            }
+        }
+
+        context("다른 커플의 포토로그에 리액션 해제를 시도하는 경우") {
+
+            it("FORBIDDEN 예외가 발생해야 함") {
+                // given
+                val otherUserId = 999L
+                val otherPhotolog = createPhotolog(otherUserId, ReactionType.ICON_HAPPY)
+
+                every { photologRepository.findById(photologId) } returns otherPhotolog
+                every { coupleService.getCoupleInfoByUserId(myUserId) } returns coupleInfo
+                every { coupleService.getPartnerUserIdByCoupleInfo(coupleInfo, myUserId) } returns partnerUserId
+
+                // when & then
+                val exception =
+                    shouldThrow<GlobalException> {
+                        photologService.removeReaction(photologId, myUserId)
+                    }
+
+                exception.getCustomMessage() shouldBe "상대방의 인증샷에만 리액션을 남길 수 있습니다."
+                verify(exactly = 0) { photologRepository.save(any()) }
+            }
+        }
+
+        context("존재하지 않는 포토로그에 리액션 해제를 시도하는 경우") {
+
+            it("NOT_FOUND 예외가 발생해야 함") {
+                // given
+                every { photologRepository.findById(photologId) } returns null
+
+                // when & then
+                val exception =
+                    shouldThrow<GlobalException> {
+                        photologService.removeReaction(photologId, myUserId)
+                    }
+
+                exception.getCustomMessage() shouldBe "인증샷을 찾을 수 없습니다."
+                verify(exactly = 0) { photologRepository.save(any()) }
+            }
+        }
+    }
 })
 

--- a/love/web/src/main/kotlin/com/yapp/love/web/photolog/PhotologApiSpec.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/photolog/PhotologApiSpec.kt
@@ -211,3 +211,91 @@ annotation class GetPhotologsByDateApiSpec
     ],
 )
 annotation class AddReactionApiSpec
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(
+    summary = "리액션 해제",
+    description = "상대방의 인증샷에 남긴 리액션을 해제합니다",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(
+            responseCode = "200",
+            description = "리액션 해제 성공",
+        ),
+        ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "인증되지 않은 사용자",
+                            value = """{"status": 401, "code": "G4010", "message": "인증되지 않은 사용자입니다."}""",
+                        ),
+                        ExampleObject(
+                            name = "토큰 만료",
+                            value = """{"status": 401, "code": "G4011", "message": "토큰이 만료되었습니다."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        ApiResponse(
+            responseCode = "403",
+            description = "권한 없음",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "자신의 인증샷",
+                            value = """{"status": 403, "code": "G4030", "message": "자신의 인증샷에는 리액션을 남길 수 없습니다."}""",
+                        ),
+                        ExampleObject(
+                            name = "다른 커플의 인증샷",
+                            value = """{"status": 403, "code": "G4030", "message": "상대방의 인증샷에만 리액션을 남길 수 있습니다."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "리소스를 찾을 수 없음",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "인증샷 없음",
+                            value = """{"status": 404, "code": "G4040", "message": "인증샷을 찾을 수 없습니다."}""",
+                        ),
+                        ExampleObject(
+                            name = "커플 해제됨",
+                            value = """{"status": 404, "code": "G4041", "message": "커플을 찾을 수 없습니다."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = [
+                Content(
+                    schema = Schema(implementation = ErrorResponse::class),
+                    examples = [
+                        ExampleObject(
+                            name = "서버 오류",
+                            value = """{"status": 500, "code": "G5000", "message": "서버 내부 오류가 발생했습니다."}""",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+annotation class RemoveReactionApiSpec

--- a/love/web/src/main/kotlin/com/yapp/love/web/photolog/PhotologController.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/photolog/PhotologController.kt
@@ -140,6 +140,15 @@ class PhotologController(
         )
     }
 
+    @RemoveReactionApiSpec
+    @DeleteMapping("/{photologId}/reaction")
+    fun removeReaction(
+        @AuthUser userId: Long,
+        @PathVariable photologId: Long,
+    ) {
+        photologService.removeReaction(photologId, userId)
+    }
+
     @Operation(summary = "인증샷 수정")
     @PutMapping("/{photologId}")
     fun updatePhotolog(


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #97

## 💻 작업 내용
- `DELETE /api/v1/photologs/{photologId}/reaction` 엔드포인트 추가
- `removeReaction()` 서비스 메서드 추가
- `addReaction` / `removeReaction` 공통 검증 로직을 `findPartnerPhotologOrThrow()`로 추출
- `@RemoveReactionApiSpec` Swagger 명세 추가
- `removeReaction` 단위 테스트 추가 (5개 케이스)

## 🧪 참고
- 리액션 해제 시 알림 발송 없음
- 이미 리액션이 없는 상태에서 해제 요청 시 에러 없이 멱등 처리