### PR TITLE
[TWI-124] fix: 양쪽 목표 완료 시 발행되던 DAILY_GOAL_ACHIEVED 알림 폐기

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEventListener.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEventListener.kt
@@ -137,19 +137,4 @@ class NotificationEventListener(
             logger.error(e) { "FCM 푸시 처리 실패: $event" }
         }
     }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun handleDailyGoalAchieved(event: DailyGoalAchievedEvent) {
-        listOf(event.user1Id, event.user2Id).forEach { targetUserId ->
-            try {
-                notificationService.sendNotification(
-                    targetUserId = targetUserId,
-                    type = NotificationType.DAILY_GOAL_ACHIEVED,
-                    titleArgs = arrayOf(event.goalName),
-                )
-            } catch (e: Exception) {
-                logger.error(e) { "알림 처리 실패: userId=$targetUserId, event=$event" }
-            }
-        }
-    }
 }

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEvents.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEvents.kt
@@ -34,12 +34,6 @@ data class ReactionCreatedEvent(
     val verificationDate: LocalDate,
 )
 
-data class DailyGoalAchievedEvent(
-    val user1Id: Long,
-    val user2Id: Long,
-    val goalName: String,
-)
-
 data class FcmPushEvent(
     val userId: Long,
     val title: String,

--- a/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
@@ -1,7 +1,6 @@
 package com.yapp.love.application.photolog
 
 import com.yapp.love.application.couple.CoupleService
-import com.yapp.love.application.notification.event.DailyGoalAchievedEvent
 import com.yapp.love.application.notification.event.PhotologCreatedEvent
 import com.yapp.love.application.notification.event.ReactionCreatedEvent
 import com.yapp.love.application.photolog.dto.ReactionInfo
@@ -124,7 +123,6 @@ class PhotologService(
         )
 
         notificationEventPublisher.publishEvent(PhotologCreatedEvent(userId = userId, goalId = goalId))
-        checkAndPublishDailyGoalAchieved(userId, goalId, verificationDate)
 
         return saved
     }
@@ -153,26 +151,6 @@ class PhotologService(
     private fun validateNoDuplicatePhotolog(goalId: Long, userId: Long, verificationDate: LocalDate) {
         photologRepository.findByGoalIdAndUserIdAndVerificationDate(goalId, userId, verificationDate)
             ?.let { throw GlobalException(GlobalErrorCode.INVALID_INPUT_VALUE, "이미 오늘 인증을 완료했습니다.") }
-    }
-
-    private fun checkAndPublishDailyGoalAchieved(userId: Long, goalId: Long, verificationDate: LocalDate) {
-        val coupleInfo = coupleInfoRepository.findByUserId(userId) ?: return
-        val goal = goalRepository.findActiveGoalById(goalId) ?: return
-
-        val photologs = photologRepository.findByGoalIdsAndVerificationDate(listOf(goalId), verificationDate)
-
-        val user1Completed = photologs.any { it.goalId == goalId && it.userId == coupleInfo.user1Id }
-        val user2Completed = photologs.any { it.goalId == goalId && it.userId == coupleInfo.user2Id }
-
-        if (user1Completed && user2Completed) {
-            notificationEventPublisher.publishEvent(
-                DailyGoalAchievedEvent(
-                    user1Id = coupleInfo.user1Id,
-                    user2Id = coupleInfo.user2Id,
-                    goalName = goal.name,
-                ),
-            )
-        }
     }
 
     @Transactional

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/event/NotificationEventListenerTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/event/NotificationEventListenerTest.kt
@@ -278,50 +278,6 @@ class NotificationEventListenerTest : DescribeSpec({
         }
     }
 
-    describe("handleDailyGoalAchieved") {
-        it("양쪽 사용자에게 DAILY_GOAL_ACHIEVED 알림을 전송한다") {
-            val event = DailyGoalAchievedEvent(user1Id = 1L, user2Id = 2L, goalName = "운동하기")
-
-            listener.handleDailyGoalAchieved(event)
-
-            verify {
-                notificationService.sendNotification(
-                    targetUserId = 1L,
-                    type = NotificationType.DAILY_GOAL_ACHIEVED,
-                    titleArgs = arrayOf("운동하기"),
-                )
-            }
-            verify {
-                notificationService.sendNotification(
-                    targetUserId = 2L,
-                    type = NotificationType.DAILY_GOAL_ACHIEVED,
-                    titleArgs = arrayOf("운동하기"),
-                )
-            }
-        }
-
-        it("user1 알림 전송 실패 시 user2에게는 정상 전송된다") {
-            val event = DailyGoalAchievedEvent(user1Id = 1L, user2Id = 2L, goalName = "운동하기")
-            every {
-                notificationService.sendNotification(
-                    targetUserId = 1L,
-                    type = any(),
-                    titleArgs = any(),
-                )
-            } throws RuntimeException("user1 DB 오류")
-
-            listener.handleDailyGoalAchieved(event) // 예외 전파 없이 종료되어야 함
-
-            verify {
-                notificationService.sendNotification(
-                    targetUserId = 2L,
-                    type = NotificationType.DAILY_GOAL_ACHIEVED,
-                    titleArgs = arrayOf("운동하기"),
-                )
-            }
-        }
-    }
-
     describe("handleFcmPush") {
         it("FCM 푸시를 전송한다") {
             val event = FcmPushEvent(userId = 1L, title = "제목", body = "내용", deepLink = "love://home")

--- a/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationTestApiSpec.kt
+++ b/love/web/src/main/kotlin/com/yapp/love/web/notification/NotificationTestApiSpec.kt
@@ -36,11 +36,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody
                         value = """{"targetUserId": 52, "type": "REACTION", "titleArgs": ["지수"], "bodyArgs": ["지수"], "deepLinkParams": {"goalId": "10", "date": "2026-02-20"}}""",
                     ),
                     ExampleObject(
-                        name = "DAILY_GOAL_ACHIEVED",
-                        summary = "데일리 목표 달성 — titleArgs[0]: 목표이름",
-                        value = """{"targetUserId": 52, "type": "DAILY_GOAL_ACHIEVED", "titleArgs": ["운동하기"], "bodyArgs": [], "deepLinkParams": {}}""",
-                    ),
-                    ExampleObject(
                         name = "GOAL_ENDED",
                         summary = "목표 종료 — titleArgs[0]: 목표이름",
                         value = """{"targetUserId": 52, "type": "GOAL_ENDED", "titleArgs": ["운동하기"], "bodyArgs": [], "deepLinkParams": {"goalId": "10"}}""",


### PR DESCRIPTION
## 배경 / 문제
포토로그 업로드 시 알림이 두 갈래로 발행됨:
1. `PhotologCreatedEvent` → 파트너에게 **GOAL_COMPLETED**
2. 양쪽 다 완료 시 `DailyGoalAchievedEvent` → **양쪽 모두에게 DAILY_GOAL_ACHIEVED**

→ 두 번째로 인증샷을 올린 사람의 파트너가 **GOAL_COMPLETED + DAILY_GOAL_ACHIEVED**를 거의 동시에 수신(푸시 폭탄). 발행이 **목표(goal)별**이라 공유 목표가 많으면 더 심함.

## 변경 내용
"양쪽 다 완료" 케이스의 알림을 **FCM·알림센터(DB) 모두에서 미발행** 처리.

- `PhotoLogService`: `checkAndPublishDailyGoalAchieved` 호출/메서드/import 제거
- `NotificationEventListener`: `handleDailyGoalAchieved` 핸들러 제거
- `NotificationEvents`: `DailyGoalAchievedEvent` 제거
- 관련 테스트(`NotificationEventListenerTest`) 및 `NotificationTestApiSpec` 예제 정리

## ⚠️ 데이터 호환성
`Notification` 엔티티가 `@Enumerated(EnumType.STRING)`이라 기존 알림 row에 `"DAILY_GOAL_ACHIEVED"` 문자열이 저장돼 있음.
→ **enum 상수 `NotificationType.DAILY_GOAL_ACHIEVED`는 유지**(삭제 시 기존 알림센터 조회 깨짐).

## 검증
- [x] `:love:application:test` 통과
- [x] web 모듈 컴파일 통과
- [x] GOAL_COMPLETED 알림 정상 동작 유지
- [x] 기존 DAILY_GOAL_ACHIEVED 알림 조회 정상 (enum 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)