### PR TITLE
fix: 과거 날짜 목표 인증 시 GOAL_COMPLETED 알림 딥링크가 오늘로 가던 버그 수정

### DIFF
--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEventListener.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEventListener.kt
@@ -11,7 +11,6 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
-import java.time.LocalDate
 
 private val logger = KotlinLogging.logger {}
 
@@ -79,7 +78,7 @@ class NotificationEventListener(
                 bodyArgs = arrayOf(nickname),
                 deepLinkParams = mapOf(
                     "goalId" to event.goalId.toString(),
-                    "date" to LocalDate.now().toString(),
+                    "date" to event.verificationDate.toString(),
                 ),
             )
         } catch (e: Exception) {

--- a/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEvents.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/notification/event/NotificationEvents.kt
@@ -18,6 +18,7 @@ data class PokedEvent(
 data class PhotologCreatedEvent(
     val userId: Long,
     val goalId: Long,
+    val verificationDate: LocalDate,
 )
 
 data class GoalEndedEvent(

--- a/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
+++ b/love/application/src/main/kotlin/com/yapp/love/application/photolog/PhotoLogService.kt
@@ -122,7 +122,9 @@ class PhotologService(
             )
         )
 
-        notificationEventPublisher.publishEvent(PhotologCreatedEvent(userId = userId, goalId = goalId))
+        notificationEventPublisher.publishEvent(
+            PhotologCreatedEvent(userId = userId, goalId = goalId, verificationDate = verificationDate),
+        )
 
         return saved
     }

--- a/love/application/src/test/kotlin/com/yapp/love/application/notification/event/NotificationEventListenerTest.kt
+++ b/love/application/src/test/kotlin/com/yapp/love/application/notification/event/NotificationEventListenerTest.kt
@@ -118,6 +118,7 @@ class NotificationEventListenerTest : DescribeSpec({
         val userId = 1L
         val partnerId = 2L
         val goalId = 10L
+        val verificationDate = LocalDate.of(2026, 1, 15)
 
         val coupleInfo = CoupleInfo(
             id = 100L,
@@ -145,7 +146,9 @@ class NotificationEventListenerTest : DescribeSpec({
                     UserAdditionInfo(userId = userId, nickname = "철수")
                 every { goalRepository.findById(goalId) } returns goal
 
-                listener.handlePhotologCreated(PhotologCreatedEvent(userId = userId, goalId = goalId))
+                listener.handlePhotologCreated(
+                    PhotologCreatedEvent(userId = userId, goalId = goalId, verificationDate = verificationDate),
+                )
 
                 verify {
                     notificationService.sendNotification(
@@ -153,7 +156,7 @@ class NotificationEventListenerTest : DescribeSpec({
                         type = NotificationType.GOAL_COMPLETED,
                         titleArgs = arrayOf("철수", "운동하기"),
                         bodyArgs = arrayOf("철수"),
-                        deepLinkParams = mapOf("goalId" to "10", "date" to LocalDate.now().toString()),
+                        deepLinkParams = mapOf("goalId" to "10", "date" to verificationDate.toString()),
                     )
                 }
             }
@@ -172,7 +175,9 @@ class NotificationEventListenerTest : DescribeSpec({
                     UserAdditionInfo(userId = userId, nickname = "철수")
                 every { goalRepository.findById(goalId) } returns goal
 
-                listener.handlePhotologCreated(PhotologCreatedEvent(userId = userId, goalId = goalId))
+                listener.handlePhotologCreated(
+                    PhotologCreatedEvent(userId = userId, goalId = goalId, verificationDate = verificationDate),
+                )
 
                 verify {
                     notificationService.sendNotification(
@@ -180,7 +185,7 @@ class NotificationEventListenerTest : DescribeSpec({
                         type = NotificationType.GOAL_COMPLETED,
                         titleArgs = arrayOf("철수", "운동하기"),
                         bodyArgs = arrayOf("철수"),
-                        deepLinkParams = mapOf("goalId" to "10", "date" to LocalDate.now().toString()),
+                        deepLinkParams = mapOf("goalId" to "10", "date" to verificationDate.toString()),
                     )
                 }
             }
@@ -192,7 +197,9 @@ class NotificationEventListenerTest : DescribeSpec({
                 every { userAdditionInfoRepository.findByUserId(userId) } returns null
                 every { goalRepository.findById(goalId) } returns goal
 
-                listener.handlePhotologCreated(PhotologCreatedEvent(userId = userId, goalId = goalId))
+                listener.handlePhotologCreated(
+                    PhotologCreatedEvent(userId = userId, goalId = goalId, verificationDate = verificationDate),
+                )
 
                 verify {
                     notificationService.sendNotification(
@@ -200,7 +207,7 @@ class NotificationEventListenerTest : DescribeSpec({
                         type = NotificationType.GOAL_COMPLETED,
                         titleArgs = arrayOf("상대방", "운동하기"),
                         bodyArgs = arrayOf("상대방"),
-                        deepLinkParams = mapOf("goalId" to "10", "date" to LocalDate.now().toString()),
+                        deepLinkParams = mapOf("goalId" to "10", "date" to verificationDate.toString()),
                     )
                 }
             }
@@ -210,7 +217,9 @@ class NotificationEventListenerTest : DescribeSpec({
             it("알림을 전송하지 않는다") {
                 every { coupleInfoRepository.findByUserId(userId) } returns null
 
-                listener.handlePhotologCreated(PhotologCreatedEvent(userId = userId, goalId = goalId))
+                listener.handlePhotologCreated(
+                    PhotologCreatedEvent(userId = userId, goalId = goalId, verificationDate = verificationDate),
+                )
 
                 verify(exactly = 0) { notificationService.sendNotification(any(), any(), any(), any(), any()) }
             }
@@ -223,7 +232,9 @@ class NotificationEventListenerTest : DescribeSpec({
                     UserAdditionInfo(userId = userId, nickname = "철수")
                 every { goalRepository.findById(goalId) } returns null
 
-                listener.handlePhotologCreated(PhotologCreatedEvent(userId = userId, goalId = goalId))
+                listener.handlePhotologCreated(
+                    PhotologCreatedEvent(userId = userId, goalId = goalId, verificationDate = verificationDate),
+                )
 
                 verify(exactly = 0) { notificationService.sendNotification(any(), any(), any(), any(), any()) }
             }


### PR DESCRIPTION
## 문제
과거 날짜로 목표를 인증하면, 파트너가 받는 "목표 완료(GOAL_COMPLETED)" 알림을 눌렀을 때 인증한 과거 날짜가 아니라 **오늘 날짜 화면**으로 이동.

## 원인
GOAL_COMPLETED 알림 딥링크의 `date` 파라미터가 인증 날짜가 아닌 `LocalDate.now()`로 설정됨 (`NotificationEventListener.handlePhotologCreated`).

근본 원인: `PhotologCreatedEvent`가 `verificationDate`를 담고 있지 않아 리스너가 `LocalDate.now()`로 대체하고 있었음.
※ POKE / REACTION 딥링크는 이미 `event.verificationDate` 사용 중.

## 변경 내용
- `PhotologCreatedEvent`에 `verificationDate` 필드 추가
- `PhotoLogService.createPhotolog()`에서 verificationDate 전달
- `handlePhotologCreated` 딥링크 `date`를 `event.verificationDate`로 변경
- 미사용 `LocalDate` import 제거
- 테스트를 과거 날짜(2026-01-15)로 검증하도록 수정

## 검증
- [x] `:love:application:test` 통과
- [x] web 모듈 컴파일 통과
- [x] 과거 날짜 인증 시 딥링크 date = 인증 날짜